### PR TITLE
Display exception when userland code contains syntax errors

### DIFF
--- a/src/load-function-module.ts
+++ b/src/load-function-module.ts
@@ -28,15 +28,18 @@ export const LoadFunctionModule = async (
     try {
       functionModule = await import(functionModuleFile);
       break;
-    } catch (_) {
-      // Error importing function module file
+    } catch (e) {
+      if (e.message.includes("[ERROR]")) {
+        // Likely means a syntax error in user code; bubble the exception up
+        throw e;
+      }
     }
     functionModuleFile = potentialFunctionFiles.shift();
   }
 
   if (!functionModule) {
     throw new Error(
-      `Could not load function module for function: ${functionCallbackId}`,
+      `Could not load function module for function: ${functionCallbackId} in ${functionDir}`,
     );
   }
 

--- a/src/tests/fixtures/functions/syntaxerror.ts
+++ b/src/tests/fixtures/functions/syntaxerror.ts
@@ -1,0 +1,4 @@
+export default async function thisShouldNotCompile() {
+  const _yes = "no";
+  return await { outputs: { ye } };
+}

--- a/src/tests/load-function-module.test.ts
+++ b/src/tests/load-function-module.test.ts
@@ -53,5 +53,15 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
   });
 
+  await t.step("should throw if function contains syntax error", async () => {
+    await assertRejects(
+      async () => {
+        return await LoadFunctionModule(generatePayload("syntaxerror"));
+      },
+      Error,
+      "[ERROR]",
+    );
+  });
+
   Deno.chdir(origDir);
 });


### PR DESCRIPTION
Right now, if you `slack run` a project with a function that contains a syntax error, you will get an extremely unhelpful error message that looks like:

```
error: Uncaught (in promise) Error: Could not load function module for function: reverse
```

This PR adds an exception inspection capability to the runner to check for error messages that contain `[ERROR]` - which, as far as I can tell, implies a typescript syntax error. This error is then raised up. In practice for a user using the `slack` CLI, the error displayed to the user then looks like this instead:

```
➜ slak run --apihost https://dev1788.slack.com --runtime deno1.19
? Choose a workspace filboxdev (Team ID: T013TBZ5QAX, App ID: A013U3XH9KL, Status: Installed)
Updating dev app install for workspace "filboxdev"
Connected, awaiting events
Check /Users/fmaj/.slack/slack-debug.log for full error logs

⚠️  Error: exit status 1
error: Uncaught (in promise) TypeError: TS2552 [ERROR]: Cannot find name 'reversString'. Did you mean 'reverseString'?
    outputs: { reversString },
               ~~~~~~~~~~~~
    at file:///Users/fmaj/src/deno-reverse-string/functions/reverse.ts:7:16

    'reverseString' is declared here.
      const reverseString = inputs.stringToReverse.split("").reverse().join("");
            ~~~~~~~~~~~~~
        at file:///Users/fmaj/src/deno-reverse-string/functions/reverse.ts:5:9
      functionModule = await import(functionModuleFile);
                       ^
    at async LoadFunctionModule (file:///Users/fmaj/src/deno-slack-runtime/src/load-function-module.ts:29:24)
    at async file:///Users/fmaj/src/deno-slack-runtime/src/mod.ts:19:26
    at async file:///Users/fmaj/src/deno-slack-runtime/src/mod.ts:7:1
```

One downside to this approach, I think, is that this won't catch syntax errors in `.js` files... I need to play around with that more to see if it is possible to catch those too.