### PR TITLE
Better handling of errors during function importing

### DIFF
--- a/src/load-function-module.ts
+++ b/src/load-function-module.ts
@@ -29,12 +29,14 @@ export const LoadFunctionModule = async (
       functionModule = await import(functionModuleFile);
       break;
     } catch (e) {
-      if (e.message.includes("[ERROR]")) {
-        // Likely means a syntax error in user code; bubble the exception up
+      if (e.message.includes("Module not found")) {
+        // Likely means the current file extension being loaded does not exist; move on to the next one
+        functionModuleFile = potentialFunctionFiles.shift();
+      } else {
+        // Any other issue other than module-not-found we should raise to the user.
         throw e;
       }
     }
-    functionModuleFile = potentialFunctionFiles.shift();
   }
 
   if (!functionModule) {

--- a/src/tests/fixtures/functions/importerror.ts
+++ b/src/tests/fixtures/functions/importerror.ts
@@ -1,0 +1,5 @@
+import * as _poo from "no-one-knows-what-this-is-really/mod.ts";
+
+export default async function thisWillFailAtRuntime() {
+  return await { outputs: { explosions: true } };
+}

--- a/src/tests/load-function-module.test.ts
+++ b/src/tests/load-function-module.test.ts
@@ -60,5 +60,15 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
   });
 
+  await t.step("should throw if function has a wrong import path", async () => {
+    await assertRejects(
+      async () => {
+        return await LoadFunctionModule(generatePayload("importerror"));
+      },
+      Error,
+      "not prefixed",
+    );
+  });
+
   Deno.chdir(origDir);
 });

--- a/src/tests/load-function-module.test.ts
+++ b/src/tests/load-function-module.test.ts
@@ -60,15 +60,18 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
   });
 
-  await t.step("should throw if function has a wrong import path", async () => {
-    await assertRejects(
-      async () => {
-        return await LoadFunctionModule(generatePayload("importerror"));
-      },
-      Error,
-      "not prefixed",
-    );
-  });
+  await t.step(
+    "should throw if function has a wrong import path (e.g. bad or missing import map)",
+    async () => {
+      await assertRejects(
+        async () => {
+          return await LoadFunctionModule(generatePayload("importerror"));
+        },
+        Error,
+        "not prefixed",
+      );
+    },
+  );
 
   Deno.chdir(origDir);
 });


### PR DESCRIPTION
An issue stemming from a wrong `run` command came up: a missing `import_map.json` caused app function code to not be able to execute due to the imports not being resolvable. However, this repo swallowed that error up and it was unclear what the problem was, all exceptions would bubble up to the user as:

```
error: Uncaught (in promise) Error: Could not load function module for function: reverse in file:///Users/nshapiro/nobackup/dev/new_hermes_apps/quizzical-lemur-781/functions
    throw new Error(
          ^
    at LoadFunctionModule (https://deno.land/x/deno_slack_runtime@0.0.3/load-function-module.ts:41:11)
```

This PR changes the logic a bit during function module loading: instead of looking for syntax error messages to raise to the user and ignoring all other exceptions, we flip this on its head. We specifically look for a module-not-found exception, and ignore it (since by the end of the load-function-module execution, we manually re-raise this error if no module is ultimately found). **All other exceptions are raised so that they bubble up to the user**. So, syntax errors in userland code, or import pathing issues in userland code, would bubble up to the user.

For example, with this PR, if you have an import pathing issue (or forgot to include your import map), when running a function you would now see:

```
error: Uncaught (in promise) TypeError: Relative import path "deno-slack-sdk/mod.ts" not prefixed with / or ./ or ../
    at file:///Users/fmaj/src/deno-reverse-string/functions/reverse.ts:1:26
      functionModule = await import(functionModuleFile);
                       ^
    at async LoadFunctionModule (http://localhost:8000/load-function-module.ts:29:24)
    at async http://localhost:8000/mod.ts:20:26
    at async http://localhost:8000/mod.ts:8:1
```

Furthermore, if you have a syntax error, you would see something like:

```
TypeError: TS2552 [ERROR]: Cannot find name 'reversString'. Did you mean 'reverseString'?
    outputs: { reversString },
               ~~~~~~~~~~~~
    at file:///Users/fmaj/src/deno-reverse-string/functions/reverse.ts:10:16

    'reverseString' is declared here.
      const reverseString = inputs.stringToReverse.split("").reverse().join("");
            ~~~~~~~~~~~~~
        at file:///Users/fmaj/src/deno-reverse-string/functions/reverse.ts:8:9
    at async LoadFunctionModule (http://localhost:8000/load-function-module.ts:29:24)
    at async http://localhost:8000/mod.ts:20:26
    at async http://localhost:8000/mod.ts:8:1
```