### PR TITLE
Splitting out local run entrypoint into own module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Helper library for running a Run on Slack Deno function. The goal of this projec
 3. Marshaling event payloads to individual functions by callback ID and running them (`src/run-function.ts`)
 4. Providing a simple Slack API client (for internal use only) (`src/client.ts`)
 
+This library has two modes of operation:
+
+1. Using `mod.ts` as the entrypoint, a directory containing function code to be loaded at runtime must be provided as an argument. This directory must contain one source file per function, with each filename matching the function ID, i.e. if a function to be invoked is identified by the id `reverse`, the provided directory argument must contain a `reverse.ts` or a `reverse.js`.
+2. Using `local-run.ts` as the entrypoint, the current working directory must contain a `manifest.json`, `manifest.ts` or `manifest.js` file, which in turn must contain function definitions that include a `source_file` property. This property is used to determine which function to load and run at runtime.
+
 ## Installation
 
 In your project, ensure your `.slack/slack.json` file has the following section:
@@ -14,21 +19,21 @@ In your project, ensure your `.slack/slack.json` file has the following section:
 ```
   "run": {
     "script": {
-      "default": "deno run -q --unstable --allow-write --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.2/mod.ts"
+      "default": "deno run -q --unstable --import-map=import_map.json --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.4/mod.ts ./directory-where-function-code-exists"
     }
   }
 ```
 
-This library assumes that function code exists in a `./functions/` relative to the root of your Run-on-Slack project.
+The value of `default` may be one of the following, depending on which mode you are operating this library in:
+
+1. Explicit function directory as argument: `deno run -q --unstable --import-map=import_map.json --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.4/mod.ts ./directory-where-function-code-exists`
+2. Local project with a manifest file: `deno run -q --unstable --import-map=import_map.json --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.4/local-run.ts`
 
 ## CLI
 
 You can also invoke this library directly from the command line, similarly to the above `slack.json` hook implementation:
 
-    deno run -q --unstable --allow-write --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.2/mod.ts [optional-project-root]
-
-The `mod.ts` entry point for this library accepts an optional absolute or relative path argument pointing to the project root.
-If no such path argument is provided, the current working directory is assumed to be the project root.
+    deno run -q --unstable --import-map=import_map.json --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.4/mod.ts <required-function-directory>
 
 ## Usage details
 
@@ -36,7 +41,7 @@ Once installed, you should be able to use the `slack` CLI to run your project lo
 
 If you would like to test this against a Slack development instance/workspace, you may need to instruct `deno` to ignore SSL certificate validation errors. You can do so by adjusting the `deno` call like so:
 
-    deno run -q --unstable --allow-write --allow-read --allow-net --unsafely-ignore-certificate-errors=dev.slack.com https://deno.land/x/deno_slack_runtime@0.0.2/mod.ts
+    deno run -q --unstable --allow-write --allow-read --allow-net --unsafely-ignore-certificate-errors=dev.slack.com https://deno.land/x/deno_slack_runtime@0.0.4/mod.ts ./functions
 
 ## Testing
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,2 +1,4 @@
 export { readAll } from "https://deno.land/std@0.99.0/io/util.ts";
 export { BaseSlackAPIClient } from "https://deno.land/x/deno_slack_api@0.0.2/base-client.ts";
+export { createManifest } from "https://deno.land/x/deno_slack_builder@0.0.7/manifest.ts";
+export { dirname } from "https://deno.land/std@0.99.0/path/mod.ts";

--- a/src/load-function-module.ts
+++ b/src/load-function-module.ts
@@ -7,15 +7,14 @@ import {
 // Given a function callback_id, import and return the corresponding function module
 // provided by the developer. This should have been bundled to live alongside the deno-runtime module
 export const LoadFunctionModule = async (
+  functionDir: string,
   payload: InvocationPayload<FunctionInvocationBody>,
 ): Promise<FunctionModule> => {
   const functionCallbackId = payload?.body?.event?.function?.callback_id;
   if (!functionCallbackId) {
     throw new Error("No callback_id provided in payload!");
   }
-  // Project root can be optionally provided after invoking the script.
-  const projectRoot = Deno.args[0] || Deno.cwd();
-  const functionDir = `file://${projectRoot}/functions`;
+
   const supportedExts = ["js", "ts"];
   const potentialFunctionFiles = supportedExts.map((ext) =>
     `${functionDir}/${functionCallbackId}.${ext}`

--- a/src/tests/load-function-module.test.ts
+++ b/src/tests/load-function-module.test.ts
@@ -5,7 +5,9 @@ import { generatePayload } from "./test_utils.ts";
 Deno.test("LoadFunctionModule function", async (t) => {
   const origDir = Deno.cwd();
   const __dirname = new URL(".", import.meta.url).pathname;
-  Deno.chdir(`${__dirname}/fixtures`);
+  const fixturesDir = `${__dirname}/fixtures`;
+  Deno.chdir(fixturesDir);
+  const functionsDir = `${fixturesDir}/functions`;
 
   await t.step(
     "should throw if a callback_id in the payload does not exist",
@@ -14,7 +16,7 @@ Deno.test("LoadFunctionModule function", async (t) => {
         async () => {
           const payload = generatePayload("funky");
           payload.body.event.function.callback_id = "";
-          return await LoadFunctionModule(payload);
+          return await LoadFunctionModule(functionsDir, payload);
         },
         Error,
         "No callback_id provided in payload!",
@@ -23,7 +25,10 @@ Deno.test("LoadFunctionModule function", async (t) => {
   );
 
   await t.step("should load typescript file if exists", async () => {
-    const tsModule = await LoadFunctionModule(generatePayload("funky"));
+    const tsModule = await LoadFunctionModule(
+      functionsDir,
+      generatePayload("funky"),
+    );
     assertEquals(
       tsModule.default.name,
       "funkyTS",
@@ -32,7 +37,10 @@ Deno.test("LoadFunctionModule function", async (t) => {
   });
 
   await t.step("should load javascript file if exists", async () => {
-    const jsModule = await LoadFunctionModule(generatePayload("wacky"));
+    const jsModule = await LoadFunctionModule(
+      functionsDir,
+      generatePayload("wacky"),
+    );
     assertEquals(
       jsModule.default.name,
       "wackyJS",
@@ -43,7 +51,10 @@ Deno.test("LoadFunctionModule function", async (t) => {
   await t.step("should throw if does not exist", async () => {
     await assertRejects(
       async () => {
-        return await LoadFunctionModule(generatePayload("nonexistent"));
+        return await LoadFunctionModule(
+          functionsDir,
+          generatePayload("nonexistent"),
+        );
       },
       Error,
       "Could not load function module for function: nonexistent",
@@ -53,7 +64,10 @@ Deno.test("LoadFunctionModule function", async (t) => {
   await t.step("should throw if function contains syntax error", async () => {
     await assertRejects(
       async () => {
-        return await LoadFunctionModule(generatePayload("syntaxerror"));
+        return await LoadFunctionModule(
+          functionsDir,
+          generatePayload("syntaxerror"),
+        );
       },
       Error,
       "[ERROR]",
@@ -65,7 +79,10 @@ Deno.test("LoadFunctionModule function", async (t) => {
     async () => {
       await assertRejects(
         async () => {
-          return await LoadFunctionModule(generatePayload("importerror"));
+          return await LoadFunctionModule(
+            functionsDir,
+            generatePayload("importerror"),
+          );
         },
         Error,
         "not prefixed",


### PR DESCRIPTION
`local-run.ts` now uses the `source_file` manifest function property to figure out where to load locally-running functions from.

The big changes:

- the existing `LoadFunctionModule` function no longer makes any assumptions about default directory conventions. FYI @curtisallen this means that the argument the Lambda context should provide to `mod.ts` should point to the full `/path/to/project/functions` directory, and not to the project root directory (as was before).
- for local run support, apps' `slack.json` `run` hook should use the `local-run.ts` entrypoint instead of `mod.ts`.

I'm leaving this as a draft PR for now to solicit early feedback. I think there's some opportunity to DRY some stuff up between `mod.ts` and `local-run.ts` - but it's not _that_ much code to factor out, so I'm not sure if it's worth it at this point? One idea was maybe the payload validation (ensuring that the payload event type is `function_executed`) could be integrated into the `ParsePayload` module? That should DRY the code between `local-run.ts` and `mod.ts` a little bit. Beyond that, while the structure of the two entrypoints is pretty much the same, it's tight enough that maybe DRYing it up is too much? WDYT?

Things I tested:

- moving function folders around in the reverse-string-with-SDK project structure; seems to work well (as long as you update the manifest's `source_file` correctly!)
- incorrectly specifying the `source_file` property; if it points to a non-existent file you will get:
    ```
    error: Uncaught (in promise) Error: Could not load function module for function: reverse in file:///Users/fmaj/src/deno-reverse-string/funs
    ```
    (I think the directory specifier at the end of the error is enough of a hint to help folks)