### PR TITLE
Make sure callback id matches the source file name during local run

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": true,
+  "[typescript]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "editor.tabSize": 2
+}

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
 export { readAll } from "https://deno.land/std@0.99.0/io/util.ts";
 export { BaseSlackAPIClient } from "https://deno.land/x/deno_slack_api@0.0.2/base-client.ts";
 export { createManifest } from "https://deno.land/x/deno_slack_builder@0.0.7/manifest.ts";
-export { dirname } from "https://deno.land/std@0.99.0/path/mod.ts";
+export { parse } from "https://deno.land/std@0.99.0/path/mod.ts";

--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -1,4 +1,4 @@
-import { createManifest, dirname, readAll } from "./deps.ts";
+import { createManifest, parse, readAll } from "./deps.ts";
 
 import { FunctionInvocationBody, InvocationPayload } from "./types.ts";
 import { ParsePayload } from "./parse-payload.ts";
@@ -36,9 +36,16 @@ export const runLocally = async function () {
       `No function definition for function callback id ${functionCallbackId} was found in the manifest! manifest.functions: ${manifest.functions}`,
     );
   }
-  const functionDir = `file://${workingDirectory}/${
-    dirname(functionDefn.source_file)
-  }`;
+
+  const { dir: sourceDir, name: sourceFilename } = parse(
+    functionDefn.source_file,
+  );
+  const functionDir = `file://${workingDirectory}/${sourceDir}`;
+
+  if (sourceFilename !== payload?.body?.event?.function.callback_id) {
+    // Override the callback_id to point at the local file name
+    payload.body.event.function.callback_id = sourceFilename;
+  }
 
   const functionModule = await LoadFunctionModule(
     functionDir,


### PR DESCRIPTION
###  Summary

Make sure the `callback_id` matches the source file name during local run.

### Details

Right now we require the `callback_id` to match the filename in `LoadFunctionModule`. This works fine for the lambda runtime where we control the files that are passed to the runtime, but when we try to run the developer's local files we are throwing an unclear error when the name of the file didn't match the `callback_id`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
