### PR TITLE
Support async and sync function handlers

### DIFF
--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -24,14 +24,12 @@ export const RunFunction = async (
     completed = true,
     outputs = {},
     error,
-  } = await functionModule.default(
-    {
-      inputs,
-      env,
-      token,
-      event: body.event,
-    },
-  );
+  } = await functionModule.default({
+    inputs,
+    env,
+    token,
+    event: body.event,
+  });
 
   // App has indicated there's an unrecoverable error with this function invocation
   if (error) {

--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -1,12 +1,9 @@
 import { BaseSlackAPIClient } from "./deps.ts";
 import {
-  AsyncFunctionHandler,
   FunctionContext,
-  FunctionHandlerReturnArgs,
   FunctionInvocationBody,
   FunctionModule,
   InvocationPayload,
-  SyncFunctionHandler,
 } from "./types.ts";
 
 export const RunFunction = async (
@@ -23,12 +20,6 @@ export const RunFunction = async (
     slackApiUrl: env["SLACK_API_URL"],
   });
 
-  const returnArgs: FunctionHandlerReturnArgs = {
-    completed: false,
-    outputs: {},
-    error: undefined,
-  };
-
   const functionContext: FunctionContext = {
     inputs,
     env,
@@ -37,45 +28,27 @@ export const RunFunction = async (
   };
 
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
-  if (functionModule.default.constructor.name === "AsyncFunction") {
-    const functionToRun = functionModule.default as AsyncFunctionHandler;
-
-    const {
-      completed = true,
-      outputs = {},
-      error,
-    } = await functionToRun(functionContext);
-
-    returnArgs.completed = completed;
-    returnArgs.outputs = outputs;
-    returnArgs.error = error;
-  } else {
-    const functionToRun = functionModule.default as SyncFunctionHandler;
-
-    const {
-      completed = true,
-      outputs = {},
-      error,
-    } = functionToRun(functionContext);
-
-    returnArgs.completed = completed;
-    returnArgs.outputs = outputs;
-    returnArgs.error = error;
-  }
+  const {
+    completed = true,
+    outputs = {},
+    error,
+  } = await functionModule.default(
+    functionContext,
+  );
 
   // App has indicated there's an unrecoverable error with this function invocation
-  if (returnArgs.error) {
+  if (error) {
     await client.apiCall("functions.completeError", {
-      error: returnArgs.error,
+      error: error,
       function_execution_id: functionExecutionId,
     });
     return;
   }
 
   // App has indicated it's function completed successfully
-  if (returnArgs.completed) {
+  if (completed) {
     await client.apiCall("functions.completeSuccess", {
-      outputs: returnArgs.outputs,
+      outputs: outputs,
       function_execution_id: functionExecutionId,
     });
     return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,9 +39,15 @@ export type FunctionContext = {
   event: FunctionInvocationBody["event"];
 };
 
-export type FunctionHandler = {
+export type AsyncFunctionHandler = {
   (context: FunctionContext): Promise<FunctionHandlerReturnArgs>;
 };
+
+export type SyncFunctionHandler = {
+  (context: FunctionContext): FunctionHandlerReturnArgs;
+};
+
+export type FunctionHandler = AsyncFunctionHandler | SyncFunctionHandler;
 
 // This is the interface a developer-provided function module should adhere to
 export type FunctionModule = {


### PR DESCRIPTION
###  Summary

This PR updates our RunFunction logic as well as types to handle synchronous and asynchronous function handlers.

### Testing

* For testing, use the local run with a local copy of the runtime. 
* You can update your `start` hook to use your local copy by updating your `slack.json` sorta like this, with your paths:

```
"start": "deno run -q --unstable --config=deno.jsonc --allow-read --allow-net /Users/<your-user>/path/to/deno-slack-runtime/src/local-run.ts"
```

* You'll also want a local copy of the SDK with the updated types for FunctionHandler (found [here](https://github.com/slackapi/deno-slack-sdk/pull/28)).
* With that setup, you can drop the `async` on a Slack Function and remove any awaits that you didn't need to verify a local run fn execution works as expected.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
