### PR TITLE
added test to validate that js file is used over invalid TS file

### DIFF
--- a/src/tests/load-function-module.test.ts
+++ b/src/tests/load-function-module.test.ts
@@ -31,6 +31,21 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
   });
 
+  await t.step("should load the js file if ts file is invalid", async () => {
+    const tsModule = await LoadFunctionModule(
+      [
+        `${functionsDir}/badFile.ts`,
+        `${functionsDir}/wacky.js`,
+      ],
+    );
+    assertExists(tsModule);
+    assertEquals(
+      tsModule.default.name,
+      "wackyJS",
+      "typescript file invalid, js file loaded",
+    );
+  });
+
   await t.step("should load typescript file if exists", async () => {
     const tsModule = await LoadFunctionModule(
       [`${functionsDir}/funky.ts`],

--- a/src/tests/load-function-module.test.ts
+++ b/src/tests/load-function-module.test.ts
@@ -32,17 +32,17 @@ Deno.test("LoadFunctionModule function", async (t) => {
   });
 
   await t.step("should load the js file if ts file is invalid", async () => {
-    const tsModule = await LoadFunctionModule(
+    const jsModule = await LoadFunctionModule(
       [
         `${functionsDir}/badFile.ts`,
         `${functionsDir}/wacky.js`,
       ],
     );
-    assertExists(tsModule);
+    assertExists(jsModule);
     assertEquals(
-      tsModule.default.name,
+      jsModule.default.name,
       "wackyJS",
-      "typescript file invalid, js file loaded",
+      "javascript file not loaded over invalid typescript file",
     );
   });
 


### PR DESCRIPTION
###  Summary

Added a new test to verify that load-function-module will load a js file over a bad ts file. #16 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
