### PR TITLE
adding view_closed and view_submission dispatching logic

### DIFF
--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -1,6 +1,8 @@
 import { LoadFunctionModule } from "./load-function-module.ts";
 import { RunFunction } from "./run-function.ts";
 import { RunBlockAction } from "./run-block-actions.ts";
+import { RunViewSubmission } from "./run-view-submission.ts";
+import { RunViewClosed } from "./run-view-closed.ts";
 import {
   BlockActionInvocationBody,
   EventTypes,
@@ -8,6 +10,8 @@ import {
   InvocationPayload,
   ValidEventType,
   ValidInvocationPayloadBody,
+  ViewClosedInvocationBody,
+  ViewSubmissionInvocationBody,
 } from "./types.ts";
 
 // Given a function callback_id, returns a set of potential function files to check
@@ -65,6 +69,18 @@ export const DispatchPayload = async (
         functionModule,
       );
       break;
+    case EventTypes.VIEW_SUBMISSION:
+      resp = await RunViewSubmission(
+        payload as InvocationPayload<ViewSubmissionInvocationBody>,
+        functionModule,
+      );
+      break;
+    case EventTypes.VIEW_CLOSED:
+      resp = await RunViewClosed(
+        payload as InvocationPayload<ViewClosedInvocationBody>,
+        functionModule,
+      );
+      break;
   }
 
   return resp || {};
@@ -80,6 +96,12 @@ function getFunctionCallbackID(
         ?.function?.callback_id ?? "";
     case EventTypes.BLOCK_ACTIONS:
       return (payload as InvocationPayload<BlockActionInvocationBody>)?.body
+        ?.function_data?.function?.callback_id ?? "";
+    case EventTypes.VIEW_CLOSED:
+      return (payload as InvocationPayload<ViewClosedInvocationBody>)?.body
+        ?.function_data?.function?.callback_id ?? "";
+    case EventTypes.VIEW_SUBMISSION:
+      return (payload as InvocationPayload<ViewSubmissionInvocationBody>)?.body
         ?.function_data?.function?.callback_id ?? "";
     default:
       return "";

--- a/src/run-view-closed.ts
+++ b/src/run-view-closed.ts
@@ -1,0 +1,38 @@
+import {
+  FunctionModule,
+  InvocationPayload,
+  ViewClosedInvocationBody,
+} from "./types.ts";
+
+export const RunViewClosed = async (
+  payload: InvocationPayload<ViewClosedInvocationBody>,
+  functionModule: FunctionModule,
+  // deno-lint-ignore no-explicit-any
+): Promise<any> => {
+  const { body, context } = payload;
+  const view = body.view;
+  const env = context.variables || {};
+  const token = body.bot_access_token || context.bot_access_token || "";
+  const inputs = body.function_data?.inputs || {};
+
+  if (!functionModule.viewClosed) {
+    console.warn(
+      "Received view_closed payload but function does not define a viewClosed handler",
+    );
+
+    // Return an ack response here by default
+    return {};
+  }
+
+  // We don't catch any errors the handlers may throw, we let them throw, and stop the process
+  // deno-lint-ignore no-explicit-any
+  const closedResp: any = await functionModule.viewClosed({
+    inputs,
+    env,
+    token,
+    body,
+    view,
+  });
+
+  return closedResp || {};
+};

--- a/src/run-view-submission.ts
+++ b/src/run-view-submission.ts
@@ -1,0 +1,38 @@
+import {
+  FunctionModule,
+  InvocationPayload,
+  ViewSubmissionInvocationBody,
+} from "./types.ts";
+
+export const RunViewSubmission = async (
+  payload: InvocationPayload<ViewSubmissionInvocationBody>,
+  functionModule: FunctionModule,
+  // deno-lint-ignore no-explicit-any
+): Promise<any> => {
+  const { body, context } = payload;
+  const view = body.view;
+  const env = context.variables || {};
+  const token = body.bot_access_token || context.bot_access_token || "";
+  const inputs = body.function_data?.inputs || {};
+
+  if (!functionModule.viewSubmission) {
+    console.warn(
+      "Received view_submission payload but function does not define a viewSubmission handler",
+    );
+
+    // Return an ack response here by default
+    return {};
+  }
+
+  // We don't catch any errors the handlers may throw, we let them throw, and stop the process
+  // deno-lint-ignore no-explicit-any
+  const submissionResp: any = await functionModule.viewSubmission({
+    inputs,
+    env,
+    token,
+    body,
+    view,
+  });
+
+  return submissionResp || {};
+};

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -1,8 +1,30 @@
-import { assertExists } from "../dev_deps.ts";
+import { assertExists, assertRejects } from "../dev_deps.ts";
 import { DispatchPayload } from "../dispatch-payload.ts";
 
 Deno.test("DispatchPayload function", async (t) => {
   await t.step("should be defined", () => {
     assertExists(DispatchPayload);
   });
+  await t.step(
+    "should throw if an unrecognized event type is dispatched",
+    async () => {
+      await assertRejects(() =>
+        DispatchPayload({
+          body: { type: "messinwitcha" },
+          context: { bot_access_token: "12345", variables: {} },
+        }, () => [])
+      );
+    },
+  );
+  await t.step(
+    "should throw if no function callback_id present in payload",
+    async () => {
+      await assertRejects(() =>
+        DispatchPayload({
+          body: { type: "function_executed", event: {} },
+          context: { bot_access_token: "12345", variables: {} },
+        }, () => [])
+      );
+    },
+  );
 });

--- a/src/tests/run-block-actions.test.ts
+++ b/src/tests/run-block-actions.test.ts
@@ -1,8 +1,41 @@
-import { assertExists } from "../dev_deps.ts";
+import { assertEquals, assertExists } from "../dev_deps.ts";
 import { RunBlockAction } from "../run-block-actions.ts";
+import { generateBlockActionsPayload } from "./test_utils.ts";
 
 Deno.test("RunBlockAction function", async (t) => {
   await t.step("should be defined", () => {
     assertExists(RunBlockAction);
   });
+
+  await t.step("should run handler", async () => {
+    const payload = generateBlockActionsPayload();
+
+    const blockActionsResp = {
+      burp: "adurp",
+    };
+
+    const fnModule = {
+      default: () => ({}),
+      blockActions: () => {
+        return blockActionsResp;
+      },
+    };
+    const resp = await RunBlockAction(payload, fnModule);
+
+    assertEquals(resp, blockActionsResp);
+  });
+
+  await t.step(
+    "should return an empty resp if no handler defined",
+    async () => {
+      const payload = generateBlockActionsPayload();
+
+      const fnModule = {
+        default: () => ({}),
+      };
+      const resp = await RunBlockAction(payload, fnModule);
+
+      assertEquals(resp, {});
+    },
+  );
 });

--- a/src/tests/run-view-closed.test.ts
+++ b/src/tests/run-view-closed.test.ts
@@ -1,0 +1,41 @@
+import { assertEquals, assertExists } from "../dev_deps.ts";
+import { RunViewClosed } from "../run-view-closed.ts";
+import { generateViewClosedPayload } from "./test_utils.ts";
+
+Deno.test("RunViewClosed function", async (t) => {
+  await t.step("should be defined", () => {
+    assertExists(RunViewClosed);
+  });
+
+  await t.step("should run handler", async () => {
+    const payload = generateViewClosedPayload();
+
+    const viewClosedResp = {
+      burp: "adurp",
+    };
+
+    const fnModule = {
+      default: () => ({}),
+      viewClosed: () => {
+        return viewClosedResp;
+      },
+    };
+    const resp = await RunViewClosed(payload, fnModule);
+
+    assertEquals(resp, viewClosedResp);
+  });
+
+  await t.step(
+    "should return an empty resp if no handler defined",
+    async () => {
+      const payload = generateViewClosedPayload();
+
+      const fnModule = {
+        default: () => ({}),
+      };
+      const resp = await RunViewClosed(payload, fnModule);
+
+      assertEquals(resp, {});
+    },
+  );
+});

--- a/src/tests/run-view-submission.test.ts
+++ b/src/tests/run-view-submission.test.ts
@@ -1,0 +1,41 @@
+import { assertEquals, assertExists } from "../dev_deps.ts";
+import { RunViewSubmission } from "../run-view-submission.ts";
+import { generateViewSubmissionPayload } from "./test_utils.ts";
+
+Deno.test("RunViewSubmission function", async (t) => {
+  await t.step("should be defined", () => {
+    assertExists(RunViewSubmission);
+  });
+
+  await t.step("should run handler", async () => {
+    const payload = generateViewSubmissionPayload();
+
+    const viewSubmissionResp = {
+      burp: "adurp",
+    };
+
+    const fnModule = {
+      default: () => ({}),
+      viewSubmission: () => {
+        return viewSubmissionResp;
+      },
+    };
+    const resp = await RunViewSubmission(payload, fnModule);
+
+    assertEquals(resp, viewSubmissionResp);
+  });
+
+  await t.step(
+    "should return an empty resp if no handler defined",
+    async () => {
+      const payload = generateViewSubmissionPayload();
+
+      const fnModule = {
+        default: () => ({}),
+      };
+      const resp = await RunViewSubmission(payload, fnModule);
+
+      assertEquals(resp, {});
+    },
+  );
+});

--- a/src/tests/test_utils.ts
+++ b/src/tests/test_utils.ts
@@ -1,4 +1,10 @@
-import { FunctionInvocationBody, InvocationPayload } from "../types.ts";
+import {
+  BlockActionInvocationBody,
+  FunctionInvocationBody,
+  InvocationPayload,
+  ViewClosedInvocationBody,
+  ViewSubmissionInvocationBody,
+} from "../types.ts";
 
 export const FAKE_ID = "ABC123";
 export const generatePayload = (
@@ -12,6 +18,60 @@ export const generatePayload = (
         function_execution_id: FAKE_ID,
         inputs: {},
       },
+    },
+    context: { bot_access_token: FAKE_ID, variables: {} },
+  };
+};
+
+export const generateBlockActionsPayload = (
+  id?: string,
+): InvocationPayload<BlockActionInvocationBody> => {
+  return {
+    body: {
+      type: "block_actions",
+      actions: [],
+      function_data: {
+        execution_id: FAKE_ID,
+        function: { callback_id: id || FAKE_ID },
+        inputs: {},
+      },
+      bot_access_token: FAKE_ID,
+    },
+    context: { bot_access_token: FAKE_ID, variables: {} },
+  };
+};
+
+export const generateViewSubmissionPayload = (
+  id?: string,
+): InvocationPayload<ViewSubmissionInvocationBody> => {
+  return {
+    body: {
+      type: "view_submission",
+      view: {},
+      function_data: {
+        execution_id: FAKE_ID,
+        function: { callback_id: id || FAKE_ID },
+        inputs: {},
+      },
+      bot_access_token: FAKE_ID,
+    },
+    context: { bot_access_token: FAKE_ID, variables: {} },
+  };
+};
+
+export const generateViewClosedPayload = (
+  id?: string,
+): InvocationPayload<ViewClosedInvocationBody> => {
+  return {
+    body: {
+      type: "view_closed",
+      view: {},
+      function_data: {
+        execution_id: FAKE_ID,
+        function: { callback_id: id || FAKE_ID },
+        inputs: {},
+      },
+      bot_access_token: FAKE_ID,
     },
     context: { bot_access_token: FAKE_ID, variables: {} },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export type InvocationPayload<Body extends ValidInvocationPayloadBody> = {
 
 export type ValidInvocationPayloadBody =
   | BlockActionInvocationBody
+  | ViewSubmissionInvocationBody
+  | ViewClosedInvocationBody
   | FunctionInvocationBody;
 
 // Invocation Bodies
@@ -35,6 +37,24 @@ export type FunctionInvocationBody = {
 export type BlockActionInvocationBody = {
   type: "block_actions";
   actions: BlockAction[];
+  bot_access_token?: string;
+  function_data?: FunctionData;
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
+};
+
+export type ViewClosedInvocationBody = {
+  type: "view_closed";
+  view: View;
+  bot_access_token?: string;
+  function_data?: FunctionData;
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
+};
+
+export type ViewSubmissionInvocationBody = {
+  type: "view_submission";
+  view: View;
   bot_access_token?: string;
   function_data?: FunctionData;
   // deno-lint-ignore no-explicit-any
@@ -73,11 +93,15 @@ export type FunctionHandler = {
 export type FunctionModule = {
   default: FunctionHandler;
   blockActions?: BlockActionsHandler;
+  viewSubmission?: ViewSubmissionHandler;
+  viewClosed?: ViewClosedHandler;
 };
 
 export const EventTypes = {
   FUNCTION_EXECUTED: "function_executed",
   BLOCK_ACTIONS: "block_actions",
+  VIEW_SUBMISSION: "view_submission",
+  VIEW_CLOSED: "view_closed",
 } as const;
 
 export type ValidEventType = typeof EventTypes[keyof typeof EventTypes];
@@ -97,4 +121,35 @@ export type BlockActionsHandlerArgs = {
 export type BlockActionsHandler = {
   // deno-lint-ignore no-explicit-any
   (args: BlockActionsHandlerArgs): Promise<any> | any;
+};
+
+// --- View Closed Types --- //
+// deno-lint-ignore no-explicit-any
+type View = any;
+
+type ViewClosedHandlerArgs = {
+  view: View;
+  body: ViewClosedInvocationBody;
+  token: string;
+  inputs: FunctionInputValues;
+  env: EnvironmentVariables;
+};
+
+type ViewClosedHandler = {
+  // deno-lint-ignore no-explicit-any
+  (args: ViewClosedHandlerArgs): Promise<any> | any;
+};
+
+// --- View Submission Types --- //
+type ViewSubmissionHandlerArgs = {
+  view: View;
+  body: ViewSubmissionInvocationBody;
+  token: string;
+  inputs: FunctionInputValues;
+  env: EnvironmentVariables;
+};
+
+type ViewSubmissionHandler = {
+  // deno-lint-ignore no-explicit-any
+  (args: ViewSubmissionHandlerArgs): Promise<any> | any;
 };


### PR DESCRIPTION
###  Summary

This adds support to dispatch `view_closed` and `view_submission` events to corresponding `viewClosed` and `viewSubmission` handlers on the function module in the same way `blockActions` handler works.

## Testing
I've added some unit tests for these handlers, and updated the block actions test as well to test running the handler.

To manually test this, there is a [corresponding PR](https://slack-github.com/bharris/interactive-approval/pull/2) into the internal `interactive-approval` example app that can be used to test this. We can test it by running it in local dev mode w/ the runtime pulled down, and then deployed w/ a new runtime layer.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
