### PR TITLE
Bump builder dependency to 0.0.14

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
 export { readAll } from "https://deno.land/std@0.99.0/io/util.ts";
 export { BaseSlackAPIClient } from "https://deno.land/x/deno_slack_api@0.0.2/base-client.ts";
-export { createManifest } from "https://deno.land/x/deno_slack_builder@0.0.7/manifest.ts";
+export { createManifest } from "https://deno.land/x/deno_slack_builder@0.0.14/manifest.ts";
 export { parse } from "https://deno.land/std@0.99.0/path/mod.ts";


### PR DESCRIPTION
This PR bumps the `deno-slack-builder` to the latest 0.0.14 release.

This change in builder avoids pulling in the entire collections deno stdlib, and instead just pulls in the required utility function (`deepMerge`) - see [the PR for context](https://github.com/slackapi/deno-slack-builder/pull/24).

This eliminates an additional warning in stdout in the lambda execution context (eliminating an extraneous warning that would show up when running `slack activity` to pull activity logs) as well as slimming down this library by ~800 kb.
