### PR TITLE
Start an API server when used in non localhost mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,21 @@ The script may be one of the following, depending on which mode you are operatin
 
 ⚠️ Don't forget to update the version specifier in the URL inside the above commands to match the version you want to test! You can also drop the `@` and the version specifier to use the latest released version. You can also use the `file:///` protocol to point to a version present on your local filesystem.
 
-### CLI
+## CLI
 
 You can also invoke this library directly from the command line:
 
-    deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.6/mod.ts ./<required-function-directory>
+    deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.0.6/mod.ts [-p <port>]
 
+Which will start an API Server that will exectue user provided code
+### GET /health
+
+Returns `200 OK` when called, the runtime will use this route to ensure the server is ready to handle requests
+
+### POST /functions
+
+Post Body contains the event payload that used to be read via stdout.
+Returns `200 OK` when there are no errors with finding and executing the expected user code. Will return a `500` otherwise.
 ## Running Tests
 
 If you make changes to this repo, or just want to make sure things are working as desired, you can run:

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
 export { readAll } from "https://deno.land/std@0.99.0/io/util.ts";
 export { BaseSlackAPIClient } from "https://deno.land/x/deno_slack_api@0.0.2/base-client.ts";
 export { createManifest } from "https://deno.land/x/deno_slack_builder@0.0.14/manifest.ts";
-export { parse } from "https://deno.land/std@0.99.0/path/mod.ts";
+export { parse } from "https://deno.land/std@0.99.0/flags/mod.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,15 +1,17 @@
 import { readAll } from "./deps.ts";
 import { ParsePayload } from "./parse-payload.ts";
 import { DispatchPayload } from "./dispatch-payload.ts";
+import { InvocationPayload } from "./types.ts";
 
-export const run = async function (functionDir: string) {
+export const run = async function (functionDir: string, input: string) {
   // Directory containing functions must be provided when invoking this script.
   if (!functionDir) {
     throw new Error("Missing function-directory argument!");
   }
   functionDir = `file://${await Deno.realPath(functionDir)}`;
 
-  const payload = await ParsePayload(readAll);
+  // const payload = await ParsePayload(readAll);
+  const payload: InvocationPayload<any> = JSON.parse(input);
 
   // For the hosted runtime, we only support js/ts files named w/ the callback_id
   // They should already be bundled into single files as part of the package uploaded
@@ -28,6 +30,37 @@ export const run = async function (functionDir: string) {
   console.log(JSON.stringify(resp || {}));
 };
 
-if (import.meta.main) {
-  await run(Deno.args[0]);
+const server = Deno.listen({ port: 8080 });
+console.log("Server listening on 8080");
+
+for await (const conn of server) {
+  // In order to not be blocking, we need to handle each connection individually
+  // without awaiting the function
+  serveHttp(conn);
 }
+
+async function serveHttp(conn: Deno.Conn) {
+  // This "upgrades" a network connection into an HTTP connection.
+  const httpConn = Deno.serveHttp(conn);
+  // Each request sent over the HTTP connection will be yielded as an async
+  // iterator from the HTTP connection.
+  for await (const requestEvent of httpConn) {
+    // The native HTTP server uses the web standard `Request` and `Response`
+    // objects.
+    console.log(`requestEvent is: ${requestEvent.request.url}`);
+    const url = new URL(requestEvent.request.url);
+    const body = await requestEvent.request.text();
+    run(url.pathname.substring(1), body);
+    // The requestEvent's `.respondWith()` method is how we send the response
+    // back to the client.
+    requestEvent.respondWith(
+      new Response(body, {
+        status: 200,
+      }),
+    );
+  }
+}
+
+// if (import.meta.main) {
+//   await run(Deno.args[0]);
+// }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -23,10 +23,7 @@ export const run = async function (functionDir: string, input: string) {
     return potentialFunctionFiles;
   });
 
-  // The CLI expects a JSON payload to be output to stdout
-  // This is formalized in the `run` hook of the CLI/SDK Tech Spec:
-  // https://corp.quip.com/0gDvAsqoaaYE/Proposal-CLI-SDK-Interface#temp:C:fOC1991c5aec8994d0db01d26260
-  console.log(JSON.stringify(resp || {}));
+  return JSON.stringify(resp || {});
 };
 
 // Start a http server that listens on the provided port
@@ -69,10 +66,11 @@ const startServer = async function (port: number) {
         const body = await requestEvent.request.text();
         try {
           // run the user code
-          await run(url.pathname.substring(1), body);
+          const response = await run(url.pathname.substring(1), body);
           return requestEvent.respondWith(
-            new Response("OK", {
+            new Response(response, {
               status: 200,
+              headers: { "Content-Type": "application/json" },
             }),
           );
         } catch (e) {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -23,7 +23,7 @@ export const run = async function (functionDir: string, input: string) {
     return potentialFunctionFiles;
   });
 
-  return JSON.stringify(resp || {});
+  return resp || {};
 };
 
 // Start a http server that listens on the provided port
@@ -66,16 +66,16 @@ const startServer = async function (port: number) {
         const body = await requestEvent.request.text();
         try {
           // run the user code
-          const response = await run(url.pathname.substring(1), body);
+          const response = await run("functions", body);
           return requestEvent.respondWith(
-            new Response(response, {
+            new Response(JSON.stringify(response), {
               status: 200,
               headers: { "Content-Type": "application/json" },
             }),
           );
         } catch (e) {
           console.error(`Unable to run user supplied module caught error ${e}`);
-          requestEvent.respondWith(
+          return requestEvent.respondWith(
             new Response(`error ${e}`, {
               status: 500,
             }),

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,7 +1,6 @@
-import { readAll } from "./deps.ts";
-import { ParsePayload } from "./parse-payload.ts";
 import { DispatchPayload } from "./dispatch-payload.ts";
 import { InvocationPayload } from "./types.ts";
+import { parse } from "./deps.ts";
 
 export const run = async function (functionDir: string, input: string) {
   // Directory containing functions must be provided when invoking this script.
@@ -10,7 +9,7 @@ export const run = async function (functionDir: string, input: string) {
   }
   functionDir = `file://${await Deno.realPath(functionDir)}`;
 
-  // const payload = await ParsePayload(readAll);
+  // deno-lint-ignore no-explicit-any
   const payload: InvocationPayload<any> = JSON.parse(input);
 
   // For the hosted runtime, we only support js/ts files named w/ the callback_id
@@ -30,37 +29,82 @@ export const run = async function (functionDir: string, input: string) {
   console.log(JSON.stringify(resp || {}));
 };
 
-const server = Deno.listen({ port: 8080 });
-console.log("Server listening on 8080");
-
-for await (const conn of server) {
-  // In order to not be blocking, we need to handle each connection individually
-  // without awaiting the function
-  serveHttp(conn);
-}
-
-async function serveHttp(conn: Deno.Conn) {
-  // This "upgrades" a network connection into an HTTP connection.
-  const httpConn = Deno.serveHttp(conn);
-  // Each request sent over the HTTP connection will be yielded as an async
-  // iterator from the HTTP connection.
-  for await (const requestEvent of httpConn) {
-    // The native HTTP server uses the web standard `Request` and `Response`
-    // objects.
-    console.log(`requestEvent is: ${requestEvent.request.url}`);
-    const url = new URL(requestEvent.request.url);
-    const body = await requestEvent.request.text();
-    run(url.pathname.substring(1), body);
-    // The requestEvent's `.respondWith()` method is how we send the response
-    // back to the client.
-    requestEvent.respondWith(
-      new Response(body, {
-        status: 200,
-      }),
-    );
+// Start a http server that listens on the provided port
+// This server exposes two routes
+//  GET  `/health`    Returns a 200 OK
+//  POST `/functions` Accepts event payload and invokes `run`
+const startServer = async function (port: number) {
+  let server;
+  try {
+    server = Deno.listen({ port });
+  } catch (e) {
+    throw new Error(`Unable to listen on ${port}, got ${e}`);
   }
-}
+  for await (const conn of server) {
+    // In order to not be blocking, we need to handle each connection individually
+    // without awaiting the function
+    serveHttp(conn);
+  }
 
-// if (import.meta.main) {
-//   await run(Deno.args[0]);
-// }
+  async function serveHttp(conn: Deno.Conn) {
+    // This "upgrades" a network connection into an HTTP connection.
+    const httpConn = Deno.serveHttp(conn);
+    // Each request sent over the HTTP connection will be yielded as an async
+    // iterator from the HTTP connection.
+    for await (const requestEvent of httpConn) {
+      // The native HTTP server uses the web standard `Request` and `Response`
+      // objects.
+
+      const url = new URL(requestEvent.request.url);
+      // A health check route
+      if (requestEvent.request.method == "GET" && url.pathname == "/health") {
+        return requestEvent.respondWith(
+          new Response("OK", {
+            status: 200,
+          }),
+        );
+      } else if (
+        requestEvent.request.method == "POST" && url.pathname == "/functions"
+      ) {
+        const body = await requestEvent.request.text();
+        try {
+          // run the user code
+          await run(url.pathname.substring(1), body);
+          return requestEvent.respondWith(
+            new Response("OK", {
+              status: 200,
+            }),
+          );
+        } catch (e) {
+          console.error(`Unable to run user supplied module caught error ${e}`);
+          requestEvent.respondWith(
+            new Response(`error ${e}`, {
+              status: 500,
+            }),
+          );
+        }
+      }
+      // catch all for any unexpected route
+      requestEvent.respondWith(
+        new Response(
+          `error unknown route ${requestEvent.request.method} ${url.pathname}`,
+          { status: 404 },
+        ),
+      );
+    }
+  }
+};
+
+if (import.meta.main) {
+  const args = parse(Deno.args);
+  let port = 8080; // default port
+  if (args.p !== undefined) {
+    port = Number(args["p"]);
+  }
+  // catch non numbers for port
+  if (!Number.isFinite(port)) {
+    throw Error("port must be number");
+  }
+
+  await startServer(port);
+}


### PR DESCRIPTION
⚠️ I don't plan on merging this until the server side pieces are ready ⚠️ 
###  Summary

Using a Deno API server that’s started during Lambda initialization and called during Lambda invocation is much faster than executing Deno as a CLI tool during invocations. Because Lambda initialization has more CPU than Lambda invocations, and loading the deno binary durning invocations is slow. 

When the API server starts up it exposes the following routes

### GET /health
Returns `200 OK` when called, the runtime will use this route to ensure the server is ready to handle requests

### POST /functions
Post Body contains the event payload that used to be read via stdout.
Returns `200 OK` when there are no errors with finding and executing the expected user code. Will return a `500` otherwise.

## Testing locally
In one shell

```console
deno run --allow-net --allow-read --unsafely-ignore-certificate-errors src/mod.ts
```

In your favorite HTTP client issue the following requests (I used the excellent [httpie](https://httpie.io/))

```console
❯ http GET :8080/health
HTTP/1.1 200 OK
content-length: 2
content-type: text/plain;charset=UTF-8
vary: Accept-Encoding

OK


❯ http POST :8080/functions < example_payload.json
HTTP/1.1 200 OK
content-length: 2
content-type: application/json
vary: Accept-Encoding

{}

❯ http POST :8080/unknownroute
HTTP/1.1 404 Not Found
content-encoding: gzip
content-length: 49
content-type: text/plain;charset=UTF-8
vary: Accept-Encoding

error unknown route POST /unknownroute
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
