### PR TITLE
switch to oak for fd savings

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -2,3 +2,4 @@ export { readAll } from "https://deno.land/std@0.99.0/io/util.ts";
 export { BaseSlackAPIClient } from "https://deno.land/x/deno_slack_api@0.0.2/base-client.ts";
 export { createManifest } from "https://deno.land/x/deno_slack_builder@0.0.14/manifest.ts";
 export { parse } from "https://deno.land/std@0.99.0/flags/mod.ts";
+export { Application, Context, Router } from "https://deno.land/x/oak/mod.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,6 +2,12 @@ import { DispatchPayload } from "./dispatch-payload.ts";
 import { InvocationPayload } from "./types.ts";
 import { Application, Context, parse, Router } from "./deps.ts";
 
+// unhandledrejection.js
+globalThis.addEventListener("unhandledrejection", (e) => {
+  console.log("unhandled rejection at:", e.promise, "reason:", e.reason);
+  e.preventDefault();
+});
+
 export const run = async function (functionDir: string, input: string) {
   // Directory containing functions must be provided when invoking this script.
   if (!functionDir) {
@@ -30,7 +36,7 @@ const startServer = async function (port: number) {
   router.get("/health", (ctx: Context) => {
     ctx.response.body = "OK";
   });
-  router.post("/function", async (ctx: Context) => {
+  router.post("/functions", async (ctx: Context) => {
     // run the user code
     const body = ctx.request.body();
     const response = await run("functions", JSON.stringify(body.value));
@@ -42,7 +48,7 @@ const startServer = async function (port: number) {
   app.use(router.allowedMethods());
   app.addEventListener(
     "listen",
-    (e) => console.log(`Listening on http://localhost:${port}`),
+    function () {},
   );
   await app.listen({ port });
 };


### PR DESCRIPTION
###  Summary

The deno server impl leads file descriptors, after debugging that for a while, switched to [oak](https://oakserver.github.io/oak/) now the fd's remain constant

``` console
❯ lsof -p 63530 | grep -v " txt " | wc -l
      15
❯ http GET :4500/health
HTTP/1.1 200 OK
content-length: 2
content-type: text/plain; charset=utf-8
date: Sat, 06 Aug 2022 00:41:50 GMT
vary: Accept-Encoding

OK


❯ lsof -p 63530 | grep -v " txt " | wc -l
      15
❯ wrk -d 20 -c 500 --latency http://localhost:4500/health
Running 20s test @ http://localhost:4500/health
  2 threads and 500 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.45s   185.28ms   1.70s    46.80%
    Req/Sec    33.59     34.39   138.00     82.35%
  Latency Distribution
     50%    1.42s
     75%    1.66s
     90%    1.67s
     99%    1.69s
  500 requests in 20.03s, 68.85KB read
  Socket errors: connect 0, read 1250, write 0, timeout 250
Requests/sec:     24.96
Transfer/sec:      3.44KB
❯ lsof -p 63530 | grep -v " txt " | wc -l
      15
```


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
