### PR TITLE
Prevent file descriptor leak from closed connections

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -35,9 +35,7 @@ const startServer = async function (port: number) {
   for await (const conn of server) {
     // In order to not be blocking, we need to handle each connection individually
     // without awaiting the function
-    (async () => {
-      await serveHttp(conn);
-    })();
+    await serveHttp(conn);
   }
 
   async function serveHttp(conn: Deno.Conn) {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -35,7 +35,7 @@ const startServer = async function (port: number) {
   for await (const conn of server) {
     // In order to not be blocking, we need to handle each connection individually
     // without awaiting the function
-    await serveHttp(conn);
+    serveHttp(conn);
   }
 
   async function serveHttp(conn: Deno.Conn) {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -56,7 +56,9 @@ const startServer = async function (port: number) {
           new Response("OK", {
             status: 200,
           }),
-        ).catch((e) => console.log(`Uncaught exception during health check: ${e}`));
+        ).catch((e) =>
+          console.log(`Uncaught exception during health check: ${e}`)
+        );
       } else if (
         requestEvent.request.method == "POST" && url.pathname == "/functions"
       ) {
@@ -69,7 +71,9 @@ const startServer = async function (port: number) {
               status: 200,
               headers: { "Content-Type": "application/json" },
             }),
-          ).catch((e) => console.log(`Uncaught exception after running user code: ${e}`));
+          ).catch((e) =>
+            console.log(`Uncaught exception after running user code: ${e}`)
+          );
         } catch (e) {
           console.error(`Unable to run user supplied module caught error ${e}`);
           await requestEvent.respondWith(
@@ -85,7 +89,9 @@ const startServer = async function (port: number) {
             `error unknown route ${requestEvent.request.method} ${url.pathname}`,
             { status: 404 },
           ),
-        ).catch((e) => console.log(`Uncaught exception on calling unexpected routes: ${e}`));
+        ).catch((e) =>
+          console.log(`Uncaught exception on calling unexpected routes: ${e}`)
+        );
       }
     }
   }


### PR DESCRIPTION
###  Summary

Problem:

Current Deno HTTP server implementation leads to file descriptor leak i.e. even after client closes connections, file descriptors on the server stay open indefinitely until we run into host OS limit - at this point, Deno surfaces `too many open files` error and completely stops serving requests. 

Solution:

`await` on `.respondWith()` method to ensure connection cleanup. Additional context in Deno documentation: https://deno.land/manual@v1.12.2/runtime/http_server_apis
```
In addition, you might want to await the promise returned in order to 
determine when to do any cleanup from for the request/response cycle.
```


### Testing 

```
// spinning up a local server
deno run -A src/mod.ts -p 4500 

// extracting the Deno server PID
ps -ef | grep deno    
503 22736 21022   0  9:26AM ttys004    0:20.55 deno run -A src/mod.ts -p 4500

// keeping track of file descriptor count 

lsof -p 22736 | grep -v " txt " | wc -l (before benchmarking)
      15
      
lsof -p 22736 | grep -v " txt " | wc -l (during benchmarking)
     515

lsof -p 22736 | grep -v " txt " | wc -l (after benchmarking)
      15

// benchmarking method

wrk -d 20 -c 500 --latency http://127.0.0.1:4500/health
 
Running 20s test @ http://127.0.0.1:4500/health
  2 threads and 500 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    12.78ms    2.36ms  98.39ms   92.63%
    Req/Sec    19.65k     1.37k   22.10k    74.00%
  Latency Distribution
     50%   12.47ms
     75%   13.41ms
     90%   14.59ms
     99%   17.54ms
  781922 requests in 20.01s, 104.40MB read
  Socket errors: connect 0, read 1352, write 2, timeout 0
Requests/sec:  39072.61
Transfer/sec:      5.22MB
```



### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
