### PR TITLE
Exposing team_id to userland handlers

### DIFF
--- a/src/run-block-actions.ts
+++ b/src/run-block-actions.ts
@@ -11,6 +11,7 @@ export const RunBlockAction = async (
 ): Promise<any> => {
   const { body, context } = payload;
   const env = context.variables || {};
+  const team_id = context.team_id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
@@ -29,6 +30,7 @@ export const RunBlockAction = async (
     inputs,
     env,
     token,
+    team_id,
     body,
     action: body.actions[0],
   });

--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -11,6 +11,7 @@ export const RunFunction = async (
 ): Promise<void> => {
   const { body, context } = payload;
   const env = context.variables || {};
+  const team_id = context.team_id || "";
   const token = body.event?.bot_access_token || context.bot_access_token || "";
   const functionExecutionId = body.event?.function_execution_id;
   const inputs = body.event?.inputs || {};
@@ -28,6 +29,7 @@ export const RunFunction = async (
     inputs,
     env,
     token,
+    team_id,
     event: body.event,
   });
 

--- a/src/run-view-closed.ts
+++ b/src/run-view-closed.ts
@@ -12,6 +12,7 @@ export const RunViewClosed = async (
   const { body, context } = payload;
   const view = body.view;
   const env = context.variables || {};
+  const team_id = context.team_id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
@@ -30,6 +31,7 @@ export const RunViewClosed = async (
     inputs,
     env,
     token,
+    team_id,
     body,
     view,
   });

--- a/src/run-view-submission.ts
+++ b/src/run-view-submission.ts
@@ -12,6 +12,7 @@ export const RunViewSubmission = async (
   const { body, context } = payload;
   const view = body.view;
   const env = context.variables || {};
+  const team_id = context.team_id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
@@ -30,6 +31,7 @@ export const RunViewSubmission = async (
     inputs,
     env,
     token,
+    team_id,
     body,
     view,
   });

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -11,7 +11,7 @@ Deno.test("DispatchPayload function", async (t) => {
       await assertRejects(() =>
         DispatchPayload({
           body: { type: "messinwitcha" },
-          context: { bot_access_token: "12345", variables: {} },
+          context: { bot_access_token: "12345", team_id: "123", variables: {} },
         }, () => [])
       );
     },
@@ -22,7 +22,7 @@ Deno.test("DispatchPayload function", async (t) => {
       await assertRejects(() =>
         DispatchPayload({
           body: { type: "function_executed", event: {} },
-          context: { bot_access_token: "12345", variables: {} },
+          context: { bot_access_token: "12345", team_id: "123", variables: {} },
         }, () => [])
       );
     },
@@ -49,6 +49,7 @@ Deno.test("DispatchPayload function file compatibility tests", async (t) => {
         },
         context: {
           bot_access_token: "",
+          team_id: "",
           variables: {},
         },
       };
@@ -75,6 +76,7 @@ Deno.test("DispatchPayload function file compatibility tests", async (t) => {
         },
         context: {
           bot_access_token: "",
+          team_id: "",
           variables: {},
         },
       };

--- a/src/tests/test_utils.ts
+++ b/src/tests/test_utils.ts
@@ -19,7 +19,7 @@ export const generatePayload = (
         inputs: {},
       },
     },
-    context: { bot_access_token: FAKE_ID, variables: {} },
+    context: { bot_access_token: FAKE_ID, team_id: FAKE_ID, variables: {} },
   };
 };
 
@@ -37,7 +37,7 @@ export const generateBlockActionsPayload = (
       },
       bot_access_token: FAKE_ID,
     },
-    context: { bot_access_token: FAKE_ID, variables: {} },
+    context: { bot_access_token: FAKE_ID, team_id: FAKE_ID, variables: {} },
   };
 };
 
@@ -55,7 +55,7 @@ export const generateViewSubmissionPayload = (
       },
       bot_access_token: FAKE_ID,
     },
-    context: { bot_access_token: FAKE_ID, variables: {} },
+    context: { bot_access_token: FAKE_ID, team_id: FAKE_ID, variables: {} },
   };
 };
 
@@ -73,6 +73,6 @@ export const generateViewClosedPayload = (
       },
       bot_access_token: FAKE_ID,
     },
-    context: { bot_access_token: FAKE_ID, variables: {} },
+    context: { bot_access_token: FAKE_ID, team_id: FAKE_ID, variables: {} },
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type InvocationPayload<Body extends ValidInvocationPayloadBody> = {
   body: Body;
   context: {
     bot_access_token: string;
+    team_id: string;
     variables: EnvironmentVariables;
   };
 };
@@ -80,6 +81,7 @@ export type FunctionHandlerArgs = {
   env: EnvironmentVariables;
   inputs: FunctionInputValues;
   token: string;
+  team_id: string;
   event: FunctionInvocationBody["event"];
 };
 
@@ -114,6 +116,7 @@ export type BlockActionsHandlerArgs = {
   action: BlockAction;
   body: BlockActionInvocationBody;
   token: string;
+  team_id: string;
   inputs: FunctionInputValues;
   env: EnvironmentVariables;
 };
@@ -131,6 +134,7 @@ type ViewClosedHandlerArgs = {
   view: View;
   body: ViewClosedInvocationBody;
   token: string;
+  team_id: string;
   inputs: FunctionInputValues;
   env: EnvironmentVariables;
 };
@@ -145,6 +149,7 @@ type ViewSubmissionHandlerArgs = {
   view: View;
   body: ViewSubmissionInvocationBody;
   token: string;
+  team_id: string;
   inputs: FunctionInputValues;
   env: EnvironmentVariables;
 };


### PR DESCRIPTION
###  Summary

There were requests internally at Slack to expose `team_id` to userland code. 

The [`InvocationContext` that is part of the payload delivered to deno-slack-runtime from webapp](https://slack-github.com/slack/slack-cloud-lambda-extension/blob/master/denoruntime/bootstrap.go#L24-L33) that the [Lambda extension feeds into deno-slack-runtime via its web server](https://slack-github.com/slack/slack-cloud-lambda-extension/blob/master/denoruntime/bootstrap.go#L144) includes team_id, so we could get it "for free".

See [this Slack thread for context](https://slack-pde.slack.com/archives/C02HWTPG26T/p1657826010372489).