### PR TITLE
Adding an unhandledEvent handler to functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "denoland.vscode-deno"
   },
-  "editor.tabSize": 2,
+  "editor.tabSize": 2
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "denoland.vscode-deno"
   },
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "deno.suggest.imports.autoDiscover": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,4 @@
     "editor.defaultFormatter": "denoland.vscode-deno"
   },
   "editor.tabSize": 2,
-  "deno.suggest.imports.autoDiscover": true,
 }

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -3,5 +3,8 @@ export {
   assertExists,
   assertRejects,
   assertStringIncludes,
-} from "https://deno.land/std@0.132.0/testing/asserts.ts";
-export * from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
+  assertThrows,
+  fail,
+} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+export * as mock from "https://deno.land/std@0.152.0/testing/mock.ts";
+export * as mockFetch from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -89,7 +89,7 @@ export const DispatchPayload = async (
   } catch (handlerError) {
     if (handlerError.name === "UnhandledEventError") {
       // Attempt to run the unhandledEvent handler if present
-      if (handlerError.name === "UnhandledEventError") {
+      if (functionModule.unhandledEvent) {
         resp = await RunUnhandledEvent(payload, functionModule);
       } else {
         console.warn(handlerError.message);

--- a/src/load-function-module.ts
+++ b/src/load-function-module.ts
@@ -2,14 +2,20 @@ import { FunctionModule } from "./types.ts";
 
 // Given a set of supported files, look for the slack function module file
 export const LoadFunctionModule = async (
-  potentialFunctionFiles: string[],
+  potentialFunctionFiles: (string | FunctionModule)[],
 ): Promise<FunctionModule | null> => {
   let functionModuleFile = potentialFunctionFiles.shift();
   let functionModule: FunctionModule | null = null;
   while (functionModuleFile) {
+    // If the module itself was provided, just return it.
+    if (typeof functionModuleFile === "object") {
+      functionModule = functionModuleFile;
+      break;
+    }
+
     // Import function module
     try {
-      functionModule = await import(functionModuleFile);
+      functionModule = await import(functionModuleFile as string);
       break;
     } catch (e) {
       if (e.message.includes("Module not found")) {

--- a/src/run-block-actions.ts
+++ b/src/run-block-actions.ts
@@ -1,5 +1,6 @@
 import {
   BlockActionInvocationBody,
+  EventTypes,
   FunctionModule,
   InvocationPayload,
 } from "./types.ts";
@@ -18,7 +19,7 @@ export const RunBlockAction = async (
 
   if (!functionModule.blockActions) {
     throw new UnhandledEventError(
-      "Received a block_actions payload but the function does not define a blockActions handler",
+      `Received a ${EventTypes.BLOCK_ACTIONS} payload but the function does not define a blockActions handler`,
     );
   }
 

--- a/src/run-block-actions.ts
+++ b/src/run-block-actions.ts
@@ -3,6 +3,7 @@ import {
   FunctionModule,
   InvocationPayload,
 } from "./types.ts";
+import { UnhandledEventError } from "./run-unhandled-event.ts";
 
 export const RunBlockAction = async (
   payload: InvocationPayload<BlockActionInvocationBody>,
@@ -16,12 +17,9 @@ export const RunBlockAction = async (
   const inputs = body.function_data?.inputs || {};
 
   if (!functionModule.blockActions) {
-    console.warn(
-      "Received block_actions payload but the function does not define a blockActions handler",
+    throw new UnhandledEventError(
+      "Received a block_actions payload but the function does not define a blockActions handler",
     );
-
-    // Return an ack response here by default
-    return {};
   }
 
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process

--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -1,9 +1,11 @@
 import { BaseSlackAPIClient } from "./deps.ts";
 import {
+  EventTypes,
   FunctionInvocationBody,
   FunctionModule,
   InvocationPayload,
 } from "./types.ts";
+import { UnhandledEventError } from "./run-unhandled-event.ts";
 
 export const RunFunction = async (
   payload: InvocationPayload<FunctionInvocationBody>,
@@ -15,6 +17,12 @@ export const RunFunction = async (
   const token = body.event?.bot_access_token || context.bot_access_token || "";
   const functionExecutionId = body.event?.function_execution_id;
   const inputs = body.event?.inputs || {};
+
+  if (!functionModule.default) {
+    throw new UnhandledEventError(
+      `Received a ${EventTypes.FUNCTION_EXECUTED} payload but the function does not define a default handler`,
+    );
+  }
 
   const client = new BaseSlackAPIClient(token, {
     slackApiUrl: env["SLACK_API_URL"],

--- a/src/run-unhandled-event.ts
+++ b/src/run-unhandled-event.ts
@@ -1,38 +1,38 @@
 import {
+  BaseEventInvocationBody,
   FunctionModule,
   InvocationPayload,
-  ViewClosedInvocationBody,
 } from "./types.ts";
-import { UnhandledEventError } from "./run-unhandled-event.ts";
 
-export const RunViewClosed = async (
-  payload: InvocationPayload<ViewClosedInvocationBody>,
+export const RunUnhandledEvent = async (
+  payload: InvocationPayload<BaseEventInvocationBody>,
   functionModule: FunctionModule,
   // deno-lint-ignore no-explicit-any
 ): Promise<any> => {
   const { body, context } = payload;
-  const view = body.view;
   const env = context.variables || {};
-  const team_id = context.team_id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
-  if (!functionModule.viewClosed) {
-    throw new UnhandledEventError(
-      "Received a view_closed payload but the function does not define a viewClosed handler",
-    );
+  if (!functionModule.unhandledEvent) {
+    throw new Error("No unhandledEvent handler");
   }
 
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
-  const closedResp: any = await functionModule.viewClosed({
+  const closedResp: any = await functionModule.unhandledEvent({
     inputs,
     env,
     token,
-    team_id,
     body,
-    view,
   });
 
   return closedResp || {};
 };
+
+export class UnhandledEventError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnhandledEventError";
+  }
+}

--- a/src/run-unhandled-event.ts
+++ b/src/run-unhandled-event.ts
@@ -11,6 +11,7 @@ export const RunUnhandledEvent = async (
 ): Promise<any> => {
   const { body, context } = payload;
   const env = context.variables || {};
+  const team_id = context.team_id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
@@ -25,6 +26,7 @@ export const RunUnhandledEvent = async (
     env,
     token,
     body,
+    team_id,
   });
 
   return closedResp || {};

--- a/src/run-view-closed.ts
+++ b/src/run-view-closed.ts
@@ -1,4 +1,5 @@
 import {
+  EventTypes,
   FunctionModule,
   InvocationPayload,
   ViewClosedInvocationBody,
@@ -19,7 +20,7 @@ export const RunViewClosed = async (
 
   if (!functionModule.viewClosed) {
     throw new UnhandledEventError(
-      "Received a view_closed payload but the function does not define a viewClosed handler",
+      `Received a ${EventTypes.VIEW_CLOSED} payload but the function does not define a viewClosed handler`,
     );
   }
 

--- a/src/run-view-submission.ts
+++ b/src/run-view-submission.ts
@@ -1,4 +1,5 @@
 import {
+  EventTypes,
   FunctionModule,
   InvocationPayload,
   ViewSubmissionInvocationBody,
@@ -19,7 +20,7 @@ export const RunViewSubmission = async (
 
   if (!functionModule.viewSubmission) {
     throw new UnhandledEventError(
-      "Received a view_submission payload but the function does not define a viewSubmission handler",
+      `Received a ${EventTypes.VIEW_SUBMISSION} payload but the function does not define a viewSubmission handler`,
     );
   }
 

--- a/src/run-view-submission.ts
+++ b/src/run-view-submission.ts
@@ -3,6 +3,7 @@ import {
   InvocationPayload,
   ViewSubmissionInvocationBody,
 } from "./types.ts";
+import { UnhandledEventError } from "./run-unhandled-event.ts";
 
 export const RunViewSubmission = async (
   payload: InvocationPayload<ViewSubmissionInvocationBody>,
@@ -17,12 +18,9 @@ export const RunViewSubmission = async (
   const inputs = body.function_data?.inputs || {};
 
   if (!functionModule.viewSubmission) {
-    console.warn(
-      "Received view_submission payload but function does not define a viewSubmission handler",
+    throw new UnhandledEventError(
+      "Received a view_submission payload but the function does not define a viewSubmission handler",
     );
-
-    // Return an ack response here by default
-    return {};
   }
 
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -122,6 +122,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
       args: [{
         body: payload.body,
         env: payload.context.variables,
+        team_id: payload.context.team_id,
         inputs: payload.body.event.inputs,
         token: payload.body.event.bot_access_token,
       }],
@@ -150,6 +151,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
         args: [{
           event: payload.body.event,
           env: payload.context.variables,
+          team_id: payload.context.team_id,
           inputs: payload.body.event.inputs,
           token: payload.body.event.bot_access_token,
         }],
@@ -175,6 +177,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
       args: [{
         body: payload.body,
         env: payload.context.variables,
+        team_id: payload.context.team_id,
         inputs: payload.body.function_data?.inputs,
         token: payload.body.bot_access_token,
       }],
@@ -205,6 +208,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
           body: payload.body,
           action: payload.body.actions[0],
           env: payload.context.variables,
+          team_id: payload.context.team_id,
           inputs: payload.body.function_data?.inputs,
           token: payload.body.bot_access_token,
         }],
@@ -230,6 +234,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
       args: [{
         body: payload.body,
         env: payload.context.variables,
+        team_id: payload.context.team_id,
         inputs: payload.body.function_data?.inputs,
         token: payload.body.bot_access_token,
       }],
@@ -260,6 +265,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
           body: payload.body,
           view: payload.body.view,
           env: payload.context.variables,
+          team_id: payload.context.team_id,
           inputs: payload.body.function_data?.inputs,
           token: payload.body.bot_access_token,
         }],
@@ -287,6 +293,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
         args: [{
           body: payload.body,
           env: payload.context.variables,
+          team_id: payload.context.team_id,
           inputs: payload.body.function_data?.inputs,
           token: payload.body.bot_access_token,
         }],
@@ -318,6 +325,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
           body: payload.body,
           view: payload.body.view,
           env: payload.context.variables,
+          team_id: payload.context.team_id,
           inputs: payload.body.function_data?.inputs,
           token: payload.body.bot_access_token,
         }],

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -324,4 +324,25 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
       });
     },
   );
+
+  await t.step(
+    "console.warn() if no matching handler provided and no unhandledEvent handler provided",
+    async () => {
+      const payload = generateBlockActionsPayload();
+
+      const fnModule = {
+        default: () => ({}),
+      };
+
+      const consoleWarnSpy = mock.spy(console, "warn");
+
+      await DispatchPayload(payload, () => {
+        return [fnModule];
+      });
+
+      mock.assertSpyCalls(consoleWarnSpy, 1);
+
+      consoleWarnSpy.restore();
+    },
+  );
 });

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -1,5 +1,16 @@
-import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  mock,
+} from "../dev_deps.ts";
 import { DispatchPayload } from "../dispatch-payload.ts";
+import {
+  generateBlockActionsPayload,
+  generatePayload,
+  generateViewClosedPayload,
+  generateViewSubmissionPayload,
+} from "./test_utils.ts";
 
 Deno.test("DispatchPayload function", async (t) => {
   await t.step("should be defined", () => {
@@ -91,4 +102,226 @@ Deno.test("DispatchPayload function file compatibility tests", async (t) => {
     },
   );
   Deno.chdir(origDir);
+});
+
+Deno.test("DispatchPayload with unhandled events", async (t) => {
+  await t.step("calls unhandledEvent with no default handler", async () => {
+    const payload = generatePayload("my_func");
+
+    const fnModule = {
+      unhandledEvent: () => ({}),
+    };
+
+    const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
+
+    await DispatchPayload(payload, () => {
+      return [fnModule];
+    });
+
+    mock.assertSpyCall(unhandledEventSpy, 0, {
+      args: [{
+        body: payload.body,
+        env: payload.context.variables,
+        inputs: payload.body.event.inputs,
+        token: payload.body.event.bot_access_token,
+      }],
+    });
+  });
+
+  await t.step(
+    "does not call unhandledEvent with default handler",
+    async () => {
+      const payload = generatePayload("my_func");
+
+      const fnModule = {
+        default: () => ({}),
+        unhandledEvent: () => ({}),
+      };
+
+      const defaultSpy = mock.spy(fnModule, "default");
+      const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
+
+      await DispatchPayload(payload, () => {
+        return [fnModule];
+      });
+
+      mock.assertSpyCalls(unhandledEventSpy, 0);
+      mock.assertSpyCall(defaultSpy, 0, {
+        args: [{
+          event: payload.body.event,
+          env: payload.context.variables,
+          inputs: payload.body.event.inputs,
+          token: payload.body.event.bot_access_token,
+        }],
+      });
+    },
+  );
+
+  await t.step("calls unhandledEvent with no blockAction handler", async () => {
+    const payload = generateBlockActionsPayload();
+
+    const fnModule = {
+      default: () => ({}),
+      unhandledEvent: () => ({}),
+    };
+
+    const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
+
+    await DispatchPayload(payload, () => {
+      return [fnModule];
+    });
+
+    mock.assertSpyCall(unhandledEventSpy, 0, {
+      args: [{
+        body: payload.body,
+        env: payload.context.variables,
+        inputs: payload.body.function_data?.inputs,
+        token: payload.body.bot_access_token,
+      }],
+    });
+  });
+
+  await t.step(
+    "does not call unhandledEvent with blockAction handler",
+    async () => {
+      const payload = generateBlockActionsPayload();
+
+      const fnModule = {
+        default: () => ({}),
+        blockActions: () => ({}),
+        unhandledEvent: () => ({}),
+      };
+
+      const blockActionsSpy = mock.spy(fnModule, "blockActions");
+      const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
+
+      await DispatchPayload(payload, () => {
+        return [fnModule];
+      });
+
+      mock.assertSpyCalls(unhandledEventSpy, 0);
+      mock.assertSpyCall(blockActionsSpy, 0, {
+        args: [{
+          body: payload.body,
+          action: payload.body.actions[0],
+          env: payload.context.variables,
+          inputs: payload.body.function_data?.inputs,
+          token: payload.body.bot_access_token,
+        }],
+      });
+    },
+  );
+
+  await t.step("calls unhandledEvent with no viewClosed handler", async () => {
+    const payload = generateViewClosedPayload();
+
+    const fnModule = {
+      default: () => ({}),
+      unhandledEvent: () => ({}),
+    };
+
+    const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
+
+    await DispatchPayload(payload, () => {
+      return [fnModule];
+    });
+
+    mock.assertSpyCall(unhandledEventSpy, 0, {
+      args: [{
+        body: payload.body,
+        env: payload.context.variables,
+        inputs: payload.body.function_data?.inputs,
+        token: payload.body.bot_access_token,
+      }],
+    });
+  });
+
+  await t.step(
+    "does not call unhandledEvent with viewClosed handler",
+    async () => {
+      const payload = generateViewClosedPayload();
+
+      const fnModule = {
+        default: () => ({}),
+        viewClosed: () => ({}),
+        unhandledEvent: () => ({}),
+      };
+
+      const viewClosedSpy = mock.spy(fnModule, "viewClosed");
+      const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
+
+      await DispatchPayload(payload, () => {
+        return [fnModule];
+      });
+
+      mock.assertSpyCalls(unhandledEventSpy, 0);
+      mock.assertSpyCall(viewClosedSpy, 0, {
+        args: [{
+          body: payload.body,
+          view: payload.body.view,
+          env: payload.context.variables,
+          inputs: payload.body.function_data?.inputs,
+          token: payload.body.bot_access_token,
+        }],
+      });
+    },
+  );
+
+  await t.step(
+    "calls unhandledEvent with no viewSubmission handler",
+    async () => {
+      const payload = generateViewSubmissionPayload();
+
+      const fnModule = {
+        default: () => ({}),
+        unhandledEvent: () => ({}),
+      };
+
+      const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
+
+      await DispatchPayload(payload, () => {
+        return [fnModule];
+      });
+
+      mock.assertSpyCall(unhandledEventSpy, 0, {
+        args: [{
+          body: payload.body,
+          env: payload.context.variables,
+          inputs: payload.body.function_data?.inputs,
+          token: payload.body.bot_access_token,
+        }],
+      });
+    },
+  );
+
+  await t.step(
+    "does not call unhandledEvent with viewSubmission handler",
+    async () => {
+      const payload = generateViewSubmissionPayload();
+
+      const fnModule = {
+        default: () => ({}),
+        viewSubmission: () => ({}),
+        unhandledEvent: () => ({}),
+      };
+
+      const viewSubmissionSpy = mock.spy(fnModule, "viewSubmission");
+      const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
+
+      await DispatchPayload(payload, () => {
+        return [fnModule];
+      });
+
+      mock.assertSpyCalls(unhandledEventSpy, 0);
+      mock.assertSpyCall(viewSubmissionSpy, 0, {
+        args: [{
+          body: payload.body,
+          view: payload.body.view,
+          env: payload.context.variables,
+          inputs: payload.body.function_data?.inputs,
+          token: payload.body.bot_access_token,
+        }],
+      });
+    },
+  );
 });

--- a/src/tests/fixtures/functions/unhandled.ts
+++ b/src/tests/fixtures/functions/unhandled.ts
@@ -1,0 +1,10 @@
+export default () => {
+  return {
+    outputs: {
+      myOutput: true,
+    },
+  };
+};
+
+export const unhandledEvent = () => {
+};

--- a/src/tests/load-function-module.test.ts
+++ b/src/tests/load-function-module.test.ts
@@ -25,7 +25,7 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
     assertExists(tsModule);
     assertEquals(
-      tsModule.default.name,
+      tsModule.default?.name,
       "funkyTS",
       "typescript file not loaded",
     );
@@ -40,7 +40,7 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
     assertExists(jsModule);
     assertEquals(
-      jsModule.default.name,
+      jsModule.default?.name,
       "wackyJS",
       "javascript file not loaded over invalid typescript file",
     );
@@ -52,7 +52,7 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
     assertExists(tsModule);
     assertEquals(
-      tsModule.default.name,
+      tsModule.default?.name,
       "funkyTS",
       "typescript file not loaded",
     );
@@ -64,7 +64,7 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
     assertExists(jsModule);
     assertEquals(
-      jsModule.default.name,
+      jsModule.default?.name,
       "wackyJS",
       "javascript file not loaded",
     );

--- a/src/tests/run-block-actions.test.ts
+++ b/src/tests/run-block-actions.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals, assertExists } from "../dev_deps.ts";
+import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunBlockAction } from "../run-block-actions.ts";
 import { generateBlockActionsPayload } from "./test_utils.ts";
+import { UnhandledEventError } from "../run-unhandled-event.ts";
 
 Deno.test("RunBlockAction function", async (t) => {
   await t.step("should be defined", () => {
@@ -26,16 +27,19 @@ Deno.test("RunBlockAction function", async (t) => {
   });
 
   await t.step(
-    "should return an empty resp if no handler defined",
+    "should throw an error if no handler defined",
     async () => {
       const payload = generateBlockActionsPayload();
 
       const fnModule = {
         default: () => ({}),
       };
-      const resp = await RunBlockAction(payload, fnModule);
 
-      assertEquals(resp, {});
+      await assertRejects(
+        () => RunBlockAction(payload, fnModule),
+        UnhandledEventError,
+        "block_actions",
+      );
     },
   );
 });

--- a/src/tests/run-function.test.ts
+++ b/src/tests/run-function.test.ts
@@ -1,26 +1,32 @@
 import { assertEquals, assertStringIncludes } from "../dev_deps.ts";
-import * as mf from "../dev_deps.ts";
+import { mockFetch } from "../dev_deps.ts";
 import { RunFunction } from "../run-function.ts";
 import { FAKE_ID, generatePayload } from "./test_utils.ts";
 
 Deno.test("RunFunction function", async (t) => {
-  mf.install(); // mock out calls to fetch
+  mockFetch.install(); // mock out calls to fetch
   await t.step(
     "should call completeError API if function fails to complete",
     async () => {
-      mf.mock("POST@/api/functions.completeError", async (req: Request) => {
-        assertEquals(req.url, "https://slack.com/api/functions.completeError");
-        const requestBody = await req.text();
-        assertStringIncludes(
-          requestBody,
-          "error=zomg%21",
-        );
-        assertStringIncludes(
-          requestBody,
-          `function_execution_id=${FAKE_ID}`,
-        );
-        return new Response('{"ok":true}');
-      });
+      mockFetch.mock(
+        "POST@/api/functions.completeError",
+        async (req: Request) => {
+          assertEquals(
+            req.url,
+            "https://slack.com/api/functions.completeError",
+          );
+          const requestBody = await req.text();
+          assertStringIncludes(
+            requestBody,
+            "error=zomg%21",
+          );
+          assertStringIncludes(
+            requestBody,
+            `function_execution_id=${FAKE_ID}`,
+          );
+          return new Response('{"ok":true}');
+        },
+      );
 
       const payload = generatePayload("someid");
       await RunFunction(payload, {
@@ -37,22 +43,25 @@ Deno.test("RunFunction function", async (t) => {
       const payload = generatePayload("someid");
       const outputs = { super: "dope" };
 
-      mf.mock("POST@/api/functions.completeSuccess", async (req: Request) => {
-        assertEquals(
-          req.url,
-          "https://slack.com/api/functions.completeSuccess",
-        );
-        const requestBody = await req.text();
-        assertStringIncludes(
-          requestBody,
-          `outputs=${encodeURIComponent(JSON.stringify(outputs))}`,
-        );
-        assertStringIncludes(
-          requestBody,
-          `function_execution_id=${FAKE_ID}`,
-        );
-        return new Response('{"ok":true}');
-      });
+      mockFetch.mock(
+        "POST@/api/functions.completeSuccess",
+        async (req: Request) => {
+          assertEquals(
+            req.url,
+            "https://slack.com/api/functions.completeSuccess",
+          );
+          const requestBody = await req.text();
+          assertStringIncludes(
+            requestBody,
+            `outputs=${encodeURIComponent(JSON.stringify(outputs))}`,
+          );
+          assertStringIncludes(
+            requestBody,
+            `function_execution_id=${FAKE_ID}`,
+          );
+          return new Response('{"ok":true}');
+        },
+      );
 
       await RunFunction(payload, {
         default: async () => {
@@ -61,5 +70,5 @@ Deno.test("RunFunction function", async (t) => {
       });
     },
   );
-  mf.uninstall();
+  mockFetch.uninstall();
 });

--- a/src/tests/run-unhandled-event.test.ts
+++ b/src/tests/run-unhandled-event.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
+import { RunUnhandledEvent } from "../run-unhandled-event.ts";
+import { generateBaseInvocationBody } from "./test_utils.ts";
+
+Deno.test("RunUnhandledEvent function", async (t) => {
+  await t.step("should be defined", () => {
+    assertExists(RunUnhandledEvent);
+  });
+
+  await t.step("should run handler", async () => {
+    const payload = generateBaseInvocationBody("something");
+
+    const fnModule = {
+      default: () => ({}),
+      unhandledEvent: () => ({ ok: true }),
+    };
+    const resp = await RunUnhandledEvent(payload, fnModule);
+
+    assertEquals(resp, { ok: true });
+  });
+
+  await t.step(
+    "should throw an error if no handler defined",
+    async () => {
+      const payload = generateBaseInvocationBody("test_type");
+
+      const fnModule = {
+        default: () => ({}),
+      };
+
+      await assertRejects(
+        () => RunUnhandledEvent(payload, fnModule),
+        Error,
+        "unhandledEvent",
+      );
+    },
+  );
+});

--- a/src/tests/run-view-closed.test.ts
+++ b/src/tests/run-view-closed.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals, assertExists } from "../dev_deps.ts";
+import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunViewClosed } from "../run-view-closed.ts";
 import { generateViewClosedPayload } from "./test_utils.ts";
+import { UnhandledEventError } from "../run-unhandled-event.ts";
 
 Deno.test("RunViewClosed function", async (t) => {
   await t.step("should be defined", () => {
@@ -33,9 +34,12 @@ Deno.test("RunViewClosed function", async (t) => {
       const fnModule = {
         default: () => ({}),
       };
-      const resp = await RunViewClosed(payload, fnModule);
 
-      assertEquals(resp, {});
+      await assertRejects(
+        () => RunViewClosed(payload, fnModule),
+        UnhandledEventError,
+        "view_closed",
+      );
     },
   );
 });

--- a/src/tests/run-view-submission.test.ts
+++ b/src/tests/run-view-submission.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals, assertExists } from "../dev_deps.ts";
+import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunViewSubmission } from "../run-view-submission.ts";
 import { generateViewSubmissionPayload } from "./test_utils.ts";
+import { UnhandledEventError } from "../run-unhandled-event.ts";
 
 Deno.test("RunViewSubmission function", async (t) => {
   await t.step("should be defined", () => {
@@ -33,9 +34,12 @@ Deno.test("RunViewSubmission function", async (t) => {
       const fnModule = {
         default: () => ({}),
       };
-      const resp = await RunViewSubmission(payload, fnModule);
 
-      assertEquals(resp, {});
+      await assertRejects(
+        () => RunViewSubmission(payload, fnModule),
+        UnhandledEventError,
+        "view_submission",
+      );
     },
   );
 });

--- a/src/tests/test_utils.ts
+++ b/src/tests/test_utils.ts
@@ -39,7 +39,7 @@ export const generateBaseInvocationBody = (
       },
       bot_access_token: FAKE_ID,
     },
-    context: { bot_access_token: FAKE_ID, variables: {} },
+    context: { team_id: FAKE_ID, bot_access_token: FAKE_ID, variables: {} },
   };
 };
 

--- a/src/tests/test_utils.ts
+++ b/src/tests/test_utils.ts
@@ -1,4 +1,5 @@
 import {
+  BaseEventInvocationBody,
   BlockActionInvocationBody,
   FunctionInvocationBody,
   InvocationPayload,
@@ -16,10 +17,29 @@ export const generatePayload = (
         type: "function_executed",
         function: { callback_id: id },
         function_execution_id: FAKE_ID,
+        bot_access_token: FAKE_ID,
         inputs: {},
       },
     },
     context: { bot_access_token: FAKE_ID, team_id: FAKE_ID, variables: {} },
+  };
+};
+
+export const generateBaseInvocationBody = (
+  type: string,
+  id?: string,
+): InvocationPayload<BaseEventInvocationBody> => {
+  return {
+    body: {
+      type,
+      function_data: {
+        execution_id: FAKE_ID,
+        function: { callback_id: id || FAKE_ID },
+        inputs: {},
+      },
+      bot_access_token: FAKE_ID,
+    },
+    context: { bot_access_token: FAKE_ID, variables: {} },
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ export type ValidInvocationPayloadBody =
   | BlockActionInvocationBody
   | ViewSubmissionInvocationBody
   | ViewClosedInvocationBody
-  | FunctionInvocationBody;
+  | FunctionInvocationBody
+  | BaseEventInvocationBody;
 
 // Invocation Bodies
 export type FunctionInvocationBody = {
@@ -35,31 +36,27 @@ export type FunctionInvocationBody = {
   };
 };
 
-export type BlockActionInvocationBody = {
+// All events other than the main function_executed one have at least these properties
+export type BaseEventInvocationBody = {
+  bot_access_token?: string;
+  function_data?: FunctionData;
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
+};
+
+export type BlockActionInvocationBody = BaseEventInvocationBody & {
   type: "block_actions";
   actions: BlockAction[];
-  bot_access_token?: string;
-  function_data?: FunctionData;
-  // deno-lint-ignore no-explicit-any
-  [key: string]: any;
 };
 
-export type ViewClosedInvocationBody = {
+export type ViewClosedInvocationBody = BaseEventInvocationBody & {
   type: "view_closed";
   view: View;
-  bot_access_token?: string;
-  function_data?: FunctionData;
-  // deno-lint-ignore no-explicit-any
-  [key: string]: any;
 };
 
-export type ViewSubmissionInvocationBody = {
+export type ViewSubmissionInvocationBody = BaseEventInvocationBody & {
   type: "view_submission";
   view: View;
-  bot_access_token?: string;
-  function_data?: FunctionData;
-  // deno-lint-ignore no-explicit-any
-  [key: string]: any;
 };
 
 type FunctionData = {
@@ -92,12 +89,22 @@ export type FunctionHandler = {
 };
 
 // This is the interface a developer-provided function module should adhere to
-export type FunctionModule = {
-  default: FunctionHandler;
-  blockActions?: BlockActionsHandler;
-  viewSubmission?: ViewSubmissionHandler;
-  viewClosed?: ViewClosedHandler;
-};
+export type FunctionModule =
+  | {
+    default: FunctionHandler;
+    blockActions?: BlockActionsHandler;
+    viewSubmission?: ViewSubmissionHandler;
+    viewClosed?: ViewClosedHandler;
+    unhandledEvent?: UnhandledEventHandler;
+  }
+  | // Allows for a function module w/ only a single unhandledEvent handler
+  {
+    unhandledEvent: UnhandledEventHandler;
+    default?: FunctionHandler;
+    blockActions?: BlockActionsHandler;
+    viewSubmission?: ViewSubmissionHandler;
+    viewClosed?: ViewClosedHandler;
+  };
 
 export const EventTypes = {
   FUNCTION_EXECUTED: "function_executed",
@@ -107,6 +114,19 @@ export const EventTypes = {
 } as const;
 
 export type ValidEventType = typeof EventTypes[keyof typeof EventTypes];
+
+// --- Unhandled Event Types --- //
+type UnhandledEventHandlerArgs = {
+  body: BaseEventInvocationBody;
+  token: string;
+  inputs: FunctionInputValues;
+  env: EnvironmentVariables;
+};
+
+type UnhandledEventHandler = {
+  // deno-lint-ignore no-explicit-any
+  (args: UnhandledEventHandlerArgs): Promise<any> | any;
+};
 
 // --- Block Actions Types -- //
 // deno-lint-ignore no-explicit-any

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,7 @@ export type ValidEventType = typeof EventTypes[keyof typeof EventTypes];
 type UnhandledEventHandlerArgs = {
   body: BaseEventInvocationBody;
   token: string;
+  team_id: string;
   inputs: FunctionInputValues;
   env: EnvironmentVariables;
 };


### PR DESCRIPTION
###  Summary

This allows slack function modules to provide a named export, `unhandledEvent`, that will be routed any events the function receives that aren't handled via a more specific handler, such as a `block_actions` event being routed to a `blockActions` handler.

```ts
export const unhandledEvent = ({ body, inputs, token, env }) => {
  console.log("This event was not handled");
};
```

While this will allow a developer to handle events otherwise unhandled, it will also allow for easier prototyping of new event types that functions may receive.

### Deeeeets
I adjusted a couple things to facilitate this:

1. `DispatchPayload()'s` main switch statement is wrapped in a try/catch. Individual "runners", like `RunFunction` now throw a typed error, `UnhandledEventError` if their corresponding export isn't present. This error is caught in DispatchPayload and  then the unhandledEvent handler is run if present, otherwise we `console.warn()` like we used to. This will allow us to throw the same error from our SDK routers if no handler matches, and let it get handled by the unhandledEvent handler.
2. I adjusted `LoadModule()` to accept an array of function modules and not just strings to function files. This made testing various flavors of modules waaaayyy easier, and felt like a worthwhile tradeoff. 🤷 

## Testing
I wrote a bunch of unit tests to cover the various scenarios that should invoke an `unhandledEvent` handler when provided.

To manually test this you'll need an interactive function, and then can add your `unhandledEvent` handler to it:

```ts
export const unhandledEvent = ({ body, inputs, token, env }) => {
  console.log("This event was not handled");
};
```

Remove/rename/comment out different interactivity handlers on your function, and verify the `unhandledEvent` handler runs when they're dispatched, i.e. a button click attempting to call a `blockActions` handler.


### Local Testing via `slack run`
You can use this version of the runtime locally by updating the `start` hook in your `slack.json` file:

```json
"start": "deno run --config=deno.jsonc --allow-read --allow-net --unsafely-ignore-certificate-errors https://raw.githubusercontent.com/slackapi/deno-slack-runtime/347843d/src/local-run.ts"
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
