### PR TITLE
update: move functions.complete* API to webapp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "deno-slack-runtime",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -2,6 +2,7 @@ import { createManifest, readAll } from "./deps.ts";
 import { ParsePayload } from "./parse-payload.ts";
 import { DispatchPayload } from "./dispatch-payload.ts";
 import { BaseSlackAPIClient } from "./deps.ts";
+import { InvocationPayload } from "./types.ts";
 
 export const runLocally = async function () {
   const workingDirectory = Deno.cwd();
@@ -33,6 +34,20 @@ export const runLocally = async function () {
     return [functionFile];
   });
 
+  callCompleteAPI(payload, resp);
+
+  // The CLI expects a JSON payload to be output to stdout
+  // This is formalized in the `run` hook of the CLI/SDK Tech Spec:
+  // https://corp.quip.com/0gDvAsqoaaYE/Proposal-CLI-SDK-Interface#temp:C:fOC1991c5aec8994d0db01d26260
+  console.log(JSON.stringify(resp || {}));
+};
+
+export const callCompleteAPI = async function (
+  // deno-lint-ignore no-explicit-any
+  payload: InvocationPayload<any>,
+  // deno-lint-ignore no-explicit-any
+  resp: any,
+) {
   const { body, context } = payload;
   const env = context.variables || {};
   const token = body.event?.bot_access_token || context.bot_access_token || "";
@@ -63,11 +78,6 @@ export const runLocally = async function () {
       function_execution_id: functionExecutionId,
     });
   }
-
-  // The CLI expects a JSON payload to be output to stdout
-  // This is formalized in the `run` hook of the CLI/SDK Tech Spec:
-  // https://corp.quip.com/0gDvAsqoaaYE/Proposal-CLI-SDK-Interface#temp:C:fOC1991c5aec8994d0db01d26260
-  console.log(JSON.stringify(resp || {}));
 };
 
 if (import.meta.main) {

--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -1,4 +1,3 @@
-import { BaseSlackAPIClient } from "./deps.ts";
 import {
   EventTypes,
   FunctionInvocationBody,
@@ -10,12 +9,12 @@ import { UnhandledEventError } from "./run-unhandled-event.ts";
 export const RunFunction = async (
   payload: InvocationPayload<FunctionInvocationBody>,
   functionModule: FunctionModule,
-): Promise<void> => {
+  // deno-lint-ignore no-explicit-any
+): Promise<any> => {
   const { body, context } = payload;
   const env = context.variables || {};
   const team_id = context.team_id || "";
   const token = body.event?.bot_access_token || context.bot_access_token || "";
-  const functionExecutionId = body.event?.function_execution_id;
   const inputs = body.event?.inputs || {};
 
   if (!functionModule.default) {
@@ -24,16 +23,9 @@ export const RunFunction = async (
     );
   }
 
-  const client = new BaseSlackAPIClient(token, {
-    slackApiUrl: env["SLACK_API_URL"],
-  });
-
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
-  const {
-    completed = true,
-    outputs = {},
-    error,
-  } = await functionModule.default({
+  // deno-lint-ignore no-explicit-any
+  const functionResponse: any = await functionModule.default({
     inputs,
     env,
     token,
@@ -41,21 +33,5 @@ export const RunFunction = async (
     event: body.event,
   });
 
-  // App has indicated there's an unrecoverable error with this function invocation
-  if (error) {
-    await client.apiCall("functions.completeError", {
-      error,
-      function_execution_id: functionExecutionId,
-    });
-    return;
-  }
-
-  // App has indicated it's function completed successfully
-  if (completed) {
-    await client.apiCall("functions.completeSuccess", {
-      outputs,
-      function_execution_id: functionExecutionId,
-    });
-    return;
-  }
+  return functionResponse || {};
 };

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -70,7 +70,9 @@ Deno.test("DispatchPayload function file compatibility tests", async (t) => {
           return [`${functionCallbackId}.js`];
         },
       );
-      assertEquals(fnModule, {});
+
+      const expected = { outputs: { yes: true } };
+      assertEquals(fnModule, expected);
     },
   );
   await t.step(

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -1,8 +1,51 @@
-import { assertExists } from "../dev_deps.ts";
-import { runLocally } from "../local-run.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+} from "../dev_deps.ts";
+import { callCompleteAPI, runLocally } from "../local-run.ts";
+import * as mf from "../dev_deps.ts";
+import { FAKE_ID, generatePayload } from "./test_utils.ts";
 
 Deno.test("runLocally function", async (t) => {
   await t.step("should be defined", () => {
     assertExists(runLocally);
   });
+
+  await t.step("should be defined", () => {
+    assertExists(callCompleteAPI);
+  });
+});
+
+Deno.test("call CompleteSuccess/Error API function", async (t) => {
+  mf.install(); // mock out calls to fetch
+
+  await t.step(
+    "should call completeSuccess API if function successfully completes",
+    async () => {
+      const payload = generatePayload("someid");
+      const outputs = { super: "dope" };
+
+      mf.mock("POST@/api/functions.completeSuccess", async (req: Request) => {
+        assertEquals(
+          req.url,
+          "https://slack.com/api/functions.completeSuccess",
+        );
+        const requestBody = await req.text();
+        assertStringIncludes(
+          requestBody,
+          `function_execution_id=${FAKE_ID}`,
+        );
+        return new Response('{"ok":true}');
+      });
+
+      await callCompleteAPI(payload, {
+        default: async () => {
+          return await { outputs };
+        },
+      });
+    },
+  );
+
+  mf.uninstall();
 });

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -4,7 +4,7 @@ import {
   assertStringIncludes,
 } from "../dev_deps.ts";
 import { callCompleteAPI, runLocally } from "../local-run.ts";
-import * as mf from "../dev_deps.ts";
+import { mockFetch } from "../dev_deps.ts";
 import { FAKE_ID, generatePayload } from "./test_utils.ts";
 
 Deno.test("runLocally function", async (t) => {
@@ -18,7 +18,7 @@ Deno.test("runLocally function", async (t) => {
 });
 
 Deno.test("call CompleteSuccess/Error API function", async (t) => {
-  mf.install(); // mock out calls to fetch
+  mockFetch.install(); // mock out calls to fetch
 
   await t.step(
     "should call completeSuccess API if function successfully completes",
@@ -26,18 +26,21 @@ Deno.test("call CompleteSuccess/Error API function", async (t) => {
       const payload = generatePayload("someid");
       const outputs = { super: "dope" };
 
-      mf.mock("POST@/api/functions.completeSuccess", async (req: Request) => {
-        assertEquals(
-          req.url,
-          "https://slack.com/api/functions.completeSuccess",
-        );
-        const requestBody = await req.text();
-        assertStringIncludes(
-          requestBody,
-          `function_execution_id=${FAKE_ID}`,
-        );
-        return new Response('{"ok":true}');
-      });
+      mockFetch.mock(
+        "POST@/api/functions.completeSuccess",
+        async (req: Request) => {
+          assertEquals(
+            req.url,
+            "https://slack.com/api/functions.completeSuccess",
+          );
+          const requestBody = await req.text();
+          assertStringIncludes(
+            requestBody,
+            `function_execution_id=${FAKE_ID}`,
+          );
+          return new Response('{"ok":true}');
+        },
+      );
 
       await callCompleteAPI(payload, {
         default: async () => {
@@ -47,5 +50,5 @@ Deno.test("call CompleteSuccess/Error API function", async (t) => {
     },
   );
 
-  mf.uninstall();
+  mockFetch.uninstall();
 });

--- a/src/tests/run-function.test.ts
+++ b/src/tests/run-function.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals, assertExists } from "../dev_deps.ts";
+import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunFunction } from "../run-function.ts";
 import { generatePayload } from "./test_utils.ts";
+import { UnhandledEventError } from "../run-unhandled-event.ts";
 
 Deno.test("RunFunction function", async (t) => {
   await t.step("should be defined", () => {
@@ -40,6 +41,23 @@ Deno.test("RunFunction function", async (t) => {
       const resp = await RunFunction(payload, errorFnModule);
 
       assertEquals(resp, errors);
+    },
+  );
+
+  await t.step(
+    "should return an empty resp if no handler defined",
+    async () => {
+      const payload = generatePayload("someid");
+
+      const fnModule = {
+        unhandledEvent: () => ({}),
+      };
+
+      await assertRejects(
+        () => RunFunction(payload, fnModule),
+        UnhandledEventError,
+        "function_executed",
+      );
     },
   );
 });

--- a/src/tests/run-function.test.ts
+++ b/src/tests/run-function.test.ts
@@ -1,67 +1,70 @@
-import { assertEquals, assertStringIncludes } from "../dev_deps.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "../dev_deps.ts";
 import { mockFetch } from "../dev_deps.ts";
 import { RunFunction } from "../run-function.ts";
 import { FAKE_ID, generatePayload } from "./test_utils.ts";
 
 Deno.test("RunFunction function", async (t) => {
+  
+  await t.step("should be defined", () => {
+    assertExists(RunFunction);
+  });
+
   mockFetch.install(); // mock out calls to fetch
   await t.step(
     "should call completeError API if function fails to complete",
     async () => {
-      mockFetch.mock(
-        "POST@/api/functions.completeError",
-        async (req: Request) => {
-          assertEquals(
-            req.url,
-            "https://slack.com/api/functions.completeError",
-          );
-          const requestBody = await req.text();
-          assertStringIncludes(
-            requestBody,
-            "error=zomg%21",
-          );
-          assertStringIncludes(
-            requestBody,
-            `function_execution_id=${FAKE_ID}`,
-          );
-          return new Response('{"ok":true}');
-        },
-      );
-
-      const payload = generatePayload("someid");
-      await RunFunction(payload, {
-        default: async () => {
-          return await { error: "zomg!" };
-        },
+      mockFetch.mock("POST@/api/functions.completeError", async (req: Request) => {
+        assertEquals(req.url, "https://slack.com/api/functions.completeError");
+        const requestBody = await req.text();
+        assertStringIncludes(
+          requestBody,
+          "error=zomg%21",
+        );
+        assertStringIncludes(
+          requestBody,
+          `function_execution_id=${FAKE_ID}`,
+        );
+        return new Response('{"ok":true}');
       });
-    },
-  );
+
+  await t.step("should run handler", async () => {
+    const outputs = { super: "dope" };
+
+    const fnModule = {
+      default: async () => {
+        return await { outputs };
+      },
+    };
+
+    const payload = generatePayload("someid");
+
+    const resp = await RunFunction(payload, fnModule);
+
+    const expected = { outputs: outputs };
+    assertEquals(resp, expected);
+  });
 
   await t.step(
-    "should call completeSuccess API if function successfully completes",
+    "should return an empty resp if run function fails",
     async () => {
       const payload = generatePayload("someid");
-      const outputs = { super: "dope" };
 
-      mockFetch.mock(
-        "POST@/api/functions.completeSuccess",
-        async (req: Request) => {
-          assertEquals(
-            req.url,
-            "https://slack.com/api/functions.completeSuccess",
-          );
-          const requestBody = await req.text();
-          assertStringIncludes(
-            requestBody,
-            `outputs=${encodeURIComponent(JSON.stringify(outputs))}`,
-          );
-          assertStringIncludes(
-            requestBody,
-            `function_execution_id=${FAKE_ID}`,
-          );
-          return new Response('{"ok":true}');
-        },
-      );
+      mockFetch.mock("POST@/api/functions.completeSuccess", async (req: Request) => {
+        assertEquals(
+          req.url,
+          "https://slack.com/api/functions.completeSuccess",
+        );
+        const requestBody = await req.text();
+        assertStringIncludes(
+          requestBody,
+          `outputs=${encodeURIComponent(JSON.stringify(outputs))}`,
+        );
+        assertStringIncludes(
+          requestBody,
+          `function_execution_id=${FAKE_ID}`,
+        );
+        return new Response('{"ok":true}');
+      });
 
       await RunFunction(payload, {
         default: async () => {


### PR DESCRIPTION
###  Summary

The goal is to help speed up lambda function execution time by moving functions.complete* API call to webapp.
[**HERMES-3514**](https://jira.tinyspeck.com/browse/HERMES-3514)
**Discussion**: [#devel-hermes-dev-experience] (https://slack-pde.slack.com/archives/C031YLK4TK9/p1659705366435509)

### Todo
Test changes with webapp

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
