### PR TITLE
Nested Function Handlers

### DIFF
--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -4,6 +4,8 @@ import { RunBlockAction } from "./run-block-actions.ts";
 import { RunViewSubmission } from "./run-view-submission.ts";
 import { RunViewClosed } from "./run-view-closed.ts";
 import {
+  hasUnhandledEventHandler,
+  isUnhandledEventError,
   RunUnhandledEvent,
   UnhandledEventError,
 } from "./run-unhandled-event.ts";
@@ -87,9 +89,9 @@ export const DispatchPayload = async (
         );
     }
   } catch (handlerError) {
-    if (handlerError.name === "UnhandledEventError") {
-      // Attempt to run the unhandledEvent handler if present
-      if (functionModule.unhandledEvent) {
+    if (isUnhandledEventError(handlerError)) {
+      // Attempt to run the unhandledEvent handler
+      if (hasUnhandledEventHandler(functionModule)) {
         resp = await RunUnhandledEvent(payload, functionModule);
       } else {
         console.warn(handlerError.message);

--- a/src/run-block-actions.ts
+++ b/src/run-block-actions.ts
@@ -17,7 +17,9 @@ export const RunBlockAction = async (
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
-  if (!functionModule.blockActions) {
+  const handler = functionModule.blockActions ||
+    functionModule.default?.blockActions;
+  if (!handler) {
     throw new UnhandledEventError(
       `Received a ${EventTypes.BLOCK_ACTIONS} payload but the function does not define a blockActions handler`,
     );
@@ -25,7 +27,7 @@ export const RunBlockAction = async (
 
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
-  const actionsResp: any = await functionModule.blockActions({
+  const actionsResp: any = await handler({
     inputs,
     env,
     token,

--- a/src/run-unhandled-event.ts
+++ b/src/run-unhandled-event.ts
@@ -15,13 +15,15 @@ export const RunUnhandledEvent = async (
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
-  if (!functionModule.unhandledEvent) {
+  const handler = functionModule.unhandledEvent ||
+    functionModule.default?.unhandledEvent;
+  if (!handler) {
     throw new Error("No unhandledEvent handler");
   }
 
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
-  const closedResp: any = await functionModule.unhandledEvent({
+  const closedResp: any = await handler({
     inputs,
     env,
     token,

--- a/src/run-unhandled-event.ts
+++ b/src/run-unhandled-event.ts
@@ -4,6 +4,8 @@ import {
   InvocationPayload,
 } from "./types.ts";
 
+export const UNHANDLED_EVENT_ERROR = "UnhandledEventError";
+
 export const RunUnhandledEvent = async (
   payload: InvocationPayload<BaseEventInvocationBody>,
   functionModule: FunctionModule,
@@ -37,6 +39,15 @@ export const RunUnhandledEvent = async (
 export class UnhandledEventError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "UnhandledEventError";
+    this.name = UNHANDLED_EVENT_ERROR;
   }
 }
+
+export const hasUnhandledEventHandler = (functionModule: FunctionModule) => {
+  return !!(functionModule.unhandledEvent ||
+    functionModule.default?.unhandledEvent);
+};
+
+export const isUnhandledEventError = (error: Error) => {
+  return error.name === UNHANDLED_EVENT_ERROR;
+};

--- a/src/run-view-closed.ts
+++ b/src/run-view-closed.ts
@@ -18,7 +18,9 @@ export const RunViewClosed = async (
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
-  if (!functionModule.viewClosed) {
+  const handler = functionModule.viewClosed ||
+    functionModule.default?.viewClosed;
+  if (!handler) {
     throw new UnhandledEventError(
       `Received a ${EventTypes.VIEW_CLOSED} payload but the function does not define a viewClosed handler`,
     );
@@ -26,7 +28,7 @@ export const RunViewClosed = async (
 
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
-  const closedResp: any = await functionModule.viewClosed({
+  const closedResp: any = await handler({
     inputs,
     env,
     token,

--- a/src/run-view-submission.ts
+++ b/src/run-view-submission.ts
@@ -18,7 +18,9 @@ export const RunViewSubmission = async (
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
-  if (!functionModule.viewSubmission) {
+  const handler = functionModule.viewSubmission ||
+    functionModule.default?.viewSubmission;
+  if (!handler) {
     throw new UnhandledEventError(
       `Received a ${EventTypes.VIEW_SUBMISSION} payload but the function does not define a viewSubmission handler`,
     );
@@ -26,7 +28,7 @@ export const RunViewSubmission = async (
 
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
-  const submissionResp: any = await functionModule.viewSubmission({
+  const submissionResp: any = await handler({
     inputs,
     env,
     token,

--- a/src/tests/run-unhandled-event.test.ts
+++ b/src/tests/run-unhandled-event.test.ts
@@ -19,6 +19,35 @@ Deno.test("RunUnhandledEvent function", async (t) => {
     assertEquals(resp, { ok: true });
   });
 
+  await t.step("should run nested handler", async () => {
+    const payload = generateBaseInvocationBody("something");
+
+    // deno-lint-ignore no-explicit-any
+    const fnModule: any = {
+      default: () => ({}),
+    };
+    fnModule.default.unhandledEvent = () => ({ ok: true });
+
+    const resp = await RunUnhandledEvent(payload, fnModule);
+
+    assertEquals(resp, { ok: true });
+  });
+
+  await t.step("should run top level handler over nested handler", async () => {
+    const payload = generateBaseInvocationBody("something");
+
+    // deno-lint-ignore no-explicit-any
+    const fnModule: any = {
+      default: () => ({}),
+      unhandledEvent: () => ({ ok: true }),
+    };
+    fnModule.default.unhandledEvent = () => ({ ok: false });
+
+    const resp = await RunUnhandledEvent(payload, fnModule);
+
+    assertEquals(resp, { ok: true });
+  });
+
   await t.step(
     "should throw an error if no handler defined",
     async () => {

--- a/src/tests/run-view-submission.test.ts
+++ b/src/tests/run-view-submission.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunViewSubmission } from "../run-view-submission.ts";
 import { generateViewSubmissionPayload } from "./test_utils.ts";
 import { UnhandledEventError } from "../run-unhandled-event.ts";
+import { FunctionModule } from "../types.ts";
 
 Deno.test("RunViewSubmission function", async (t) => {
   await t.step("should be defined", () => {
@@ -21,6 +22,24 @@ Deno.test("RunViewSubmission function", async (t) => {
         return viewSubmissionResp;
       },
     };
+    const resp = await RunViewSubmission(payload, fnModule);
+
+    assertEquals(resp, viewSubmissionResp);
+  });
+
+  await t.step("should run nested handler", async () => {
+    const payload = generateViewSubmissionPayload();
+
+    const viewSubmissionResp = {
+      burp: "adurp",
+    };
+
+    const fnModule: FunctionModule = {
+      default: () => ({}),
+      viewSubmission: () => viewSubmissionResp,
+    };
+    fnModule.default.viewSubmission = () => ({ no: "way" });
+
     const resp = await RunViewSubmission(payload, fnModule);
 
     assertEquals(resp, viewSubmissionResp);

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,23 +88,25 @@ export type FunctionHandler = {
   ): Promise<FunctionHandlerReturnArgs> | FunctionHandlerReturnArgs;
 };
 
+type FunctionHandlers = {
+  blockActions?: BlockActionsHandler;
+  viewSubmission?: ViewSubmissionHandler;
+  viewClosed?: ViewClosedHandler;
+  unhandledEvent?: UnhandledEventHandler;
+};
+
+type MainFunctionHandler = FunctionHandler & FunctionHandlers;
+
 // This is the interface a developer-provided function module should adhere to
 export type FunctionModule =
-  | {
-    default: FunctionHandler;
-    blockActions?: BlockActionsHandler;
-    viewSubmission?: ViewSubmissionHandler;
-    viewClosed?: ViewClosedHandler;
-    unhandledEvent?: UnhandledEventHandler;
-  }
+  | ({
+    default: MainFunctionHandler;
+  } & FunctionHandlers)
   | // Allows for a function module w/ only a single unhandledEvent handler
-  {
+  ({
+    default?: MainFunctionHandler;
     unhandledEvent: UnhandledEventHandler;
-    default?: FunctionHandler;
-    blockActions?: BlockActionsHandler;
-    viewSubmission?: ViewSubmissionHandler;
-    viewClosed?: ViewClosedHandler;
-  };
+  } & Omit<FunctionHandlers, "unhandledEvent">);
 
 export const EventTypes = {
   FUNCTION_EXECUTED: "function_executed",


### PR DESCRIPTION
###  Summary

This PR updates how we find function handlers to allow for nesting them on the `default` export. This allows for some flexibility with how we can simplify providing an interface to defining a function and it's handlers w/ a single export.

Currently, a function can export the following top level handlers:

```ts
// main function handler
export default = () => {}

// handler for all block_actions events
export const blockActions = () => {}

// handler for all view_submission events
export const viewSubmission = () => {}

// handler for all view_closed events
export const viewClosed = () => {}

// handler for all unhandled events
export const unhandledEvent = () => {}
```

These changes allow for the `default` export of the function to also contain the following properties as handlers:

* `blockActions`
* `viewSubmission`
* `viewClosed`
* `unhandledEvent`

Top level handler exports will take precedence over ones nested under the `default` export.

## Testing
I've added a bunch of test for both nested, and non-nested handlers into our suit.

While this is meant to enable a simpler interface for defining functions that's in progress [here](https://github.com/slackapi/deno-slack-sdk/pull/84), it can be tested by nesting handlers on the default export. This probably means removing some of the types you might have on those handlers.

```ts
const myFunction: any = async ({ inputs, token, env }: any) => {
  //... main handler
};

myFunction.unhandledEvent = ({ body, inputs, token }: any) => {
  console.log("unhandledEvent handler");
};

export default myFunction;
```

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
