### PR TITLE
Don't throw if no function callback_id was found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store?
 
 .coverage
+lcov.info

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -11,6 +11,7 @@
   },
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test -A src",
-    "coverage": "deno test -A --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test .coverage"
+    "coverage": "deno test -A --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test .coverage",
+    "coverage-lcov": "deno test -A --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test .coverage --lcov --output=lcov.info"
   }
 }

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,6 +1,7 @@
 export {
   assertEquals,
   assertExists,
+  assertMatch,
   assertRejects,
   assertStringIncludes,
   assertThrows,

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -36,8 +36,14 @@ export const DispatchPayload = async (
 
   const functionCallbackId = getFunctionCallbackID(eventType, payload);
 
+  // If we can't find a callback_id, we'll warn about it, then ack the event so we don't retry.
   if (!functionCallbackId) {
-    throw new Error("Could not find the function callback_id in the payload");
+    console.warn(
+      `Could not find the function callback_id in the payload for an event type of ${
+        eventType || "unknown"
+      }`,
+    );
+    return {};
   }
 
   // Let caller resolve the function directory

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -39,9 +39,9 @@ export const DispatchPayload = async (
   // If we can't find a callback_id, we'll warn about it, then ack the event so we don't retry.
   if (!functionCallbackId) {
     console.warn(
-      `Could not find the function callback_id in the payload for an event type of ${
+      `Could not find the function "callback_id" in the payload for an event type of "${
         eventType || "unknown"
-      }`,
+      }"`,
     );
     return {};
   }

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -1,6 +1,7 @@
 import {
   assertEquals,
   assertExists,
+  assertMatch,
   assertRejects,
   mock,
 } from "../dev_deps.ts";
@@ -44,7 +45,7 @@ Deno.test("DispatchPayload function", async (t) => {
 
       mock.assertSpyCalls(warnSpy, 1);
       const warnMsg = warnSpy.calls[0].args[0] as string;
-      assertEquals(/function_executed/.test(warnMsg), true);
+      assertMatch(warnMsg, /function_executed/);
       assertEquals(result, {});
 
       warnSpy.restore();
@@ -64,7 +65,7 @@ Deno.test("DispatchPayload function", async (t) => {
 
       mock.assertSpyCalls(warnSpy, 1);
       const warnMsg = warnSpy.calls[0].args[0] as string;
-      assertEquals(/some_random_type/.test(warnMsg), true);
+      assertMatch(warnMsg, /some_random_type/);
       assertEquals(result, {});
     },
   );
@@ -81,7 +82,7 @@ Deno.test("DispatchPayload function", async (t) => {
 
       mock.assertSpyCalls(warnSpy, 1);
       const warnMsg = warnSpy.calls[0].args[0] as string;
-      assertEquals(/unknown/.test(warnMsg), true);
+      assertMatch(warnMsg, /unknown/);
       assertEquals(result, {});
     },
   );


### PR DESCRIPTION
###  Summary
Fixes #32 

This adjusts how we handle the scenario of not being able to find a function's `callback_id` in the payload body. Currently if we can't find a function `callback_id` in the payload body we throw an error, which results in the event that was delivered not being acknowledged, and then retried later. If the app receives an event it can't route anywhere, we shouldn't keep retrying, so this logs a warning, and then returns a response that will result in the event being acknowledged, and no retries will happen.

### Testing
Add the following in your `slack.json` file in an app to use this version of the runtime for local dev mode:

```json
"start": "deno run -q --config=deno.jsonc --allow-read --allow-net https://raw.githubusercontent.com/slackapi/deno-slack-runtime/97beb82/src/local-run.ts"
```

To test this, you'll need to setup an app to receive an event type that doesn't have a function `callback_id` included in the payload. One way to do this is to include a `multi_external_select` in a block-kit view (like a modal or message). 

```ts
{
  block_id: "topics",
  type: "section",
  text: { type: "mrkdwn", text: "Select the meeting topics" },
  accessory: {
    action_id: "topics-action",
    type: "multi_external_select",
    min_query_length: 1,
    placeholder: {
      type: "plain_text",
      text: "Select",
      emoji: true,
    },
  },
}
```
Including this in a view, and then focusing that select input and typing will cause a `block_suggestion` event type to be sent to your app. This event doesn't yet include function metadata, so you should see the following error on your console:

```
Could not find the function "callback_id" in the payload for an event type of "block_suggestion"
```

In your view, you'll see that there are no results, which is expected since we weren't able to handle the event and provide options (yet! - support is coming soon).
![image](https://user-images.githubusercontent.com/367275/191790799-abcd1151-c1c6-4ce1-a5ff-ba9211ff157a.png)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
