### PR TITLE
Handle uncaught promise rejections

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,6 +2,12 @@ import { DispatchPayload } from "./dispatch-payload.ts";
 import { InvocationPayload } from "./types.ts";
 import { parse } from "./deps.ts";
 
+// unhandledrejection.js
+globalThis.addEventListener("unhandledrejection", (e) => {
+  console.log("unhandled rejection at:", e.promise, "reason:", e.reason);
+  e.preventDefault();
+});
+
 export const run = async function (functionDir: string, input: string) {
   // Directory containing functions must be provided when invoking this script.
   if (!functionDir) {


### PR DESCRIPTION
###  Summary

Problem:

Current Deno HTTP server implementation crashes when user code throws errors in async functions

Solution:

Use global listener on `unhandledrejection` event. Released in Deno `1.24` https://deno.com/blog/v1.24#unhandledrejection-event. Tested in below setup - will followup with extensive tests.
```
deno 1.24.3 (release, x86_64-apple-darwin)
v8 10.4.132.20
typescript 4.7.4
```


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
