### PR TITLE
HERMES-3608: Do not hide "Module not found" errors during import - plus local-run tests via dependency injection

### DIFF
--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -43,11 +43,6 @@ export const DispatchPayload = async (
   // Let caller resolve how to import the function module
   const potentialFunctionFile = getFunctionFile(functionCallbackId);
   const functionModule = await LoadFunctionModule(potentialFunctionFile);
-  if (!functionModule) {
-    throw new Error(
-      `Could not load function module for function: "${functionCallbackId}" from ${potentialFunctionFile}\nMake sure your function's "source_file" is relative to your project root.`,
-    );
-  }
 
   // This response gets passed back to the layer calling the runtime
   // and potentially used as the response to the incoming request

--- a/src/load-function-module.ts
+++ b/src/load-function-module.ts
@@ -1,32 +1,18 @@
 import { FunctionModule } from "./types.ts";
 
-// Given a set of supported files, look for the slack function module file
+/**
+ * Given a string to a path for a module, or a module itself, import the module
+ * and return
+ */
 export const LoadFunctionModule = async (
-  potentialFunctionFiles: (string | FunctionModule)[],
+  potentialFunctionFile: string | FunctionModule,
 ): Promise<FunctionModule | null> => {
-  let functionModuleFile = potentialFunctionFiles.shift();
-  let functionModule: FunctionModule | null = null;
-  while (functionModuleFile) {
-    // If the module itself was provided, just return it.
-    if (typeof functionModuleFile === "object") {
-      functionModule = functionModuleFile;
-      break;
-    }
-
-    // Import function module
-    try {
-      functionModule = await import(functionModuleFile as string);
-      break;
-    } catch (e) {
-      if (e.message.includes("Module not found")) {
-        // Likely means the current file extension being loaded does not exist; move on to the next one
-        functionModuleFile = potentialFunctionFiles.shift();
-      } else {
-        // Any other issue other than module-not-found we should raise to the user.
-        throw e;
-      }
-    }
+  // If the module itself was provided, just return it.
+  if (typeof potentialFunctionFile === "object") {
+    return potentialFunctionFile;
   }
 
-  return functionModule;
+  // Let exceptions be thrown, error would bubble up in both local and
+  // remote running contexts.
+  return await import(potentialFunctionFile as string);
 };

--- a/src/load-function-module.ts
+++ b/src/load-function-module.ts
@@ -6,7 +6,7 @@ import { FunctionModule } from "./types.ts";
  */
 export const LoadFunctionModule = async (
   potentialFunctionFile: string | FunctionModule,
-): Promise<FunctionModule | null> => {
+): Promise<FunctionModule> => {
   // If the module itself was provided, just return it.
   if (typeof potentialFunctionFile === "object") {
     return potentialFunctionFile;

--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -29,7 +29,7 @@ export const runLocally = async function () {
     const functionFile =
       `file://${workingDirectory}/${functionDefn.source_file}`;
 
-    return [functionFile];
+    return functionFile;
   });
 
   // The CLI expects a JSON payload to be output to stdout

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -12,6 +12,8 @@ import {
   generateViewSubmissionPayload,
 } from "./test_utils.ts";
 
+const noop = () => "";
+
 Deno.test("DispatchPayload function", async (t) => {
   await t.step("should be defined", () => {
     assertExists(DispatchPayload);
@@ -23,7 +25,7 @@ Deno.test("DispatchPayload function", async (t) => {
         DispatchPayload({
           body: { type: "messinwitcha" },
           context: { bot_access_token: "12345", team_id: "123", variables: {} },
-        }, () => [])
+        }, noop)
       );
     },
   );
@@ -34,7 +36,7 @@ Deno.test("DispatchPayload function", async (t) => {
         DispatchPayload({
           body: { type: "function_executed", event: {} },
           context: { bot_access_token: "12345", team_id: "123", variables: {} },
-        }, () => [])
+        }, noop)
       );
     },
   );
@@ -67,7 +69,7 @@ Deno.test("DispatchPayload function file compatibility tests", async (t) => {
       const fnModule = await DispatchPayload(
         payload,
         (functionCallbackId) => {
-          return [`${functionCallbackId}.js`];
+          return `${functionCallbackId}.js`;
         },
       );
       assertEquals(fnModule, {});
@@ -94,10 +96,11 @@ Deno.test("DispatchPayload function file compatibility tests", async (t) => {
       await assertRejects(
         async () => {
           return await DispatchPayload(payload, (functionCallbackId) => {
-            return [`${functionCallbackId}.js`];
+            return `${functionCallbackId}.js`;
           });
         },
         Error,
+        "Module not found",
       );
     },
   );
@@ -114,9 +117,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
 
     const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
 
-    await DispatchPayload(payload, () => {
-      return [fnModule];
-    });
+    await DispatchPayload(payload, () => fnModule);
 
     mock.assertSpyCall(unhandledEventSpy, 0, {
       args: [{
@@ -142,9 +143,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
       const defaultSpy = mock.spy(fnModule, "default");
       const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
 
-      await DispatchPayload(payload, () => {
-        return [fnModule];
-      });
+      await DispatchPayload(payload, () => fnModule);
 
       mock.assertSpyCalls(unhandledEventSpy, 0);
       mock.assertSpyCall(defaultSpy, 0, {
@@ -169,9 +168,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
 
     const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
 
-    await DispatchPayload(payload, () => {
-      return [fnModule];
-    });
+    await DispatchPayload(payload, () => fnModule);
 
     mock.assertSpyCall(unhandledEventSpy, 0, {
       args: [{
@@ -198,9 +195,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
       const blockActionsSpy = mock.spy(fnModule, "blockActions");
       const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
 
-      await DispatchPayload(payload, () => {
-        return [fnModule];
-      });
+      await DispatchPayload(payload, () => fnModule);
 
       mock.assertSpyCalls(unhandledEventSpy, 0);
       mock.assertSpyCall(blockActionsSpy, 0, {
@@ -226,9 +221,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
 
     const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
 
-    await DispatchPayload(payload, () => {
-      return [fnModule];
-    });
+    await DispatchPayload(payload, () => fnModule);
 
     mock.assertSpyCall(unhandledEventSpy, 0, {
       args: [{
@@ -255,9 +248,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
       const viewClosedSpy = mock.spy(fnModule, "viewClosed");
       const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
 
-      await DispatchPayload(payload, () => {
-        return [fnModule];
-      });
+      await DispatchPayload(payload, () => fnModule);
 
       mock.assertSpyCalls(unhandledEventSpy, 0);
       mock.assertSpyCall(viewClosedSpy, 0, {
@@ -285,9 +276,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
 
       const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
 
-      await DispatchPayload(payload, () => {
-        return [fnModule];
-      });
+      await DispatchPayload(payload, () => fnModule);
 
       mock.assertSpyCall(unhandledEventSpy, 0, {
         args: [{
@@ -315,9 +304,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
       const viewSubmissionSpy = mock.spy(fnModule, "viewSubmission");
       const unhandledEventSpy = mock.spy(fnModule, "unhandledEvent");
 
-      await DispatchPayload(payload, () => {
-        return [fnModule];
-      });
+      await DispatchPayload(payload, () => fnModule);
 
       mock.assertSpyCalls(unhandledEventSpy, 0);
       mock.assertSpyCall(viewSubmissionSpy, 0, {
@@ -344,9 +331,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
 
       const consoleWarnSpy = mock.spy(console, "warn");
 
-      await DispatchPayload(payload, () => {
-        return [fnModule];
-      });
+      await DispatchPayload(payload, () => fnModule);
 
       mock.assertSpyCalls(consoleWarnSpy, 1);
 

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -48,21 +48,7 @@ Deno.test("DispatchPayload function file compatibility tests", async (t) => {
   await t.step(
     "return from provided file",
     async () => {
-      const payload = {
-        body: {
-          event: {
-            function: {
-              callback_id: `${functionsDir}/wacky`,
-            },
-            type: "function_executed",
-          },
-        },
-        context: {
-          bot_access_token: "",
-          team_id: "",
-          variables: {},
-        },
-      };
+      const payload = generatePayload(`${functionsDir}/wacky`);
       const fnModule = await DispatchPayload(
         payload,
         (functionCallbackId) => {
@@ -75,21 +61,7 @@ Deno.test("DispatchPayload function file compatibility tests", async (t) => {
   await t.step(
     "file not found",
     async () => {
-      const payload = {
-        body: {
-          event: {
-            function: {
-              callback_id: `${functionsDir}/funky`,
-            },
-            type: "function_executed",
-          },
-        },
-        context: {
-          bot_access_token: "",
-          team_id: "",
-          variables: {},
-        },
-      };
+      const payload = generatePayload(`${functionsDir}/funky`);
       await assertRejects(
         async () => {
           return await DispatchPayload(payload, (functionCallbackId) => {

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -19,28 +19,25 @@ Deno.test("DispatchPayload function", async (t) => {
     assertExists(DispatchPayload);
   });
   await t.step(
-    "should throw if an unrecognized event type is dispatched",
-    async () => {
-      await assertRejects(() =>
-        DispatchPayload({
-          body: { type: "messinwitcha" },
-          context: { bot_access_token: "12345", team_id: "123", variables: {} },
-        }, noop)
-      );
-    },
-  );
-  await t.step(
     "should throw if no function callback_id present in payload",
     async () => {
-      await assertRejects(() =>
-        DispatchPayload({
-          body: { type: "function_executed", event: {} },
-          context: { bot_access_token: "12345", team_id: "123", variables: {} },
-        }, noop)
+      await assertRejects(
+        () =>
+          DispatchPayload({
+            body: { type: "function_executed", event: {} },
+            context: {
+              bot_access_token: "12345",
+              team_id: "123",
+              variables: {},
+            },
+          }, noop),
+        Error,
+        "not find the function callback_id",
       );
     },
   );
 });
+
 Deno.test("DispatchPayload function file compatibility tests", async (t) => {
   const origDir = Deno.cwd();
   const __dirname = new URL(".", import.meta.url).pathname;

--- a/src/tests/load-function-module.test.ts
+++ b/src/tests/load-function-module.test.ts
@@ -8,48 +8,8 @@ Deno.test("LoadFunctionModule function", async (t) => {
   Deno.chdir(fixturesDir);
   const functionsDir = `${fixturesDir}/functions`;
 
-  await t.step(
-    "should return null if no files are provided",
-    async () => {
-      const fnModule = await LoadFunctionModule([]);
-      assertEquals(fnModule, null);
-    },
-  );
-
-  await t.step("should load the correct file when given multiple", async () => {
-    const tsModule = await LoadFunctionModule(
-      [
-        `${functionsDir}/funky.js`,
-        `${functionsDir}/funky.ts`,
-      ],
-    );
-    assertExists(tsModule);
-    assertEquals(
-      tsModule.default?.name,
-      "funkyTS",
-      "typescript file not loaded",
-    );
-  });
-
-  await t.step("should load the js file if ts file is invalid", async () => {
-    const jsModule = await LoadFunctionModule(
-      [
-        `${functionsDir}/badFile.ts`,
-        `${functionsDir}/wacky.js`,
-      ],
-    );
-    assertExists(jsModule);
-    assertEquals(
-      jsModule.default?.name,
-      "wackyJS",
-      "javascript file not loaded over invalid typescript file",
-    );
-  });
-
   await t.step("should load typescript file if exists", async () => {
-    const tsModule = await LoadFunctionModule(
-      [`${functionsDir}/funky.ts`],
-    );
+    const tsModule = await LoadFunctionModule(`${functionsDir}/funky.ts`);
     assertExists(tsModule);
     assertEquals(
       tsModule.default?.name,
@@ -59,9 +19,7 @@ Deno.test("LoadFunctionModule function", async (t) => {
   });
 
   await t.step("should load javascript file if exists", async () => {
-    const jsModule = await LoadFunctionModule(
-      [`${functionsDir}/wacky.js`],
-    );
+    const jsModule = await LoadFunctionModule(`${functionsDir}/wacky.js`);
     assertExists(jsModule);
     assertEquals(
       jsModule.default?.name,
@@ -70,14 +28,12 @@ Deno.test("LoadFunctionModule function", async (t) => {
     );
   });
 
-  await t.step("should throw if does not exist", async () => {
-    const jsModule = await LoadFunctionModule(
-      [`${functionsDir}/nonexistnent.ts`],
-    );
-    assertEquals(
-      jsModule,
-      null,
-      "Could not load function module for function: nonexistent",
+  await t.step("should throw if file does not exist", async () => {
+    await assertRejects(
+      async () => {
+        return await LoadFunctionModule(`${functionsDir}/nonexistnent.ts`);
+      },
+      "Module not found",
     );
   });
 
@@ -85,7 +41,7 @@ Deno.test("LoadFunctionModule function", async (t) => {
     await assertRejects(
       async () => {
         return await LoadFunctionModule(
-          [`${functionsDir}/syntaxerror.ts`],
+          `${functionsDir}/syntaxerror.ts`,
         );
       },
       TypeError,
@@ -99,7 +55,7 @@ Deno.test("LoadFunctionModule function", async (t) => {
       await assertRejects(
         async () => {
           return await LoadFunctionModule(
-            [`${functionsDir}/importerror.ts`],
+            `${functionsDir}/importerror.ts`,
           );
         },
         Error,

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -1,8 +1,64 @@
-import { assertExists } from "../dev_deps.ts";
+import { assertExists, assertRejects } from "../dev_deps.ts";
 import { runLocally } from "../local-run.ts";
+import { BaseEventInvocationBody, InvocationPayload } from "../types.ts";
+
+const ID = "1234";
+/*
+// deno-lint-ignore no-explicit-any
+const fakeManifest = async (_: any): Promise<any> => {
+  return await {
+    functions: {
+      [ID]: {
+        source_file: "some/file.ts",
+      },
+    },
+  };
+};
+*/
+const noop = () => Promise.resolve(null);
+// deno-lint-ignore no-explicit-any
+const fakeParse = async (_: any): Promise<InvocationPayload<any>> => {
+  return await {} as InvocationPayload<BaseEventInvocationBody>;
+};
+const fakeStdinReader = (
+  // deno-lint-ignore no-explicit-any
+  _: any,
+): Promise<Uint8Array> => Promise.resolve(new Uint8Array(0));
 
 Deno.test("runLocally function", async (t) => {
   await t.step("should be defined", () => {
     assertExists(runLocally);
   });
+  await t.step(
+    "should throw if manifest does not contain a functions field",
+    async () => {
+      await assertRejects(
+        () =>
+          runLocally(
+            (_) => Promise.resolve({ whatever: false }),
+            fakeParse,
+            fakeStdinReader,
+            noop,
+          ),
+        Error,
+        "No function definitions",
+      );
+    },
+  );
+  await t.step(
+    "should throw if manifest does not contain a function definition that matches payload function callback ID",
+    async () => {
+      await assertRejects(
+        () =>
+          runLocally(
+            (_) => (Promise.resolve({ functions: {} })),
+            fakeParse,
+            fakeStdinReader,
+            (_, getFile) => Promise.resolve(getFile(ID)),
+          ),
+        Error,
+        "No function definition for function callback id",
+      );
+    },
+  );
 });

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -1,9 +1,8 @@
-import { assertExists, assertRejects } from "../dev_deps.ts";
+import { assertExists, assertRejects, mock } from "../dev_deps.ts";
 import { runLocally } from "../local-run.ts";
 import { BaseEventInvocationBody, InvocationPayload } from "../types.ts";
 
 const ID = "1234";
-/*
 // deno-lint-ignore no-explicit-any
 const fakeManifest = async (_: any): Promise<any> => {
   return await {
@@ -14,7 +13,6 @@ const fakeManifest = async (_: any): Promise<any> => {
     },
   };
 };
-*/
 const noop = () => Promise.resolve(null);
 // deno-lint-ignore no-explicit-any
 const fakeParse = async (_: any): Promise<InvocationPayload<any>> => {
@@ -25,7 +23,7 @@ const fakeStdinReader = (
   _: any,
 ): Promise<Uint8Array> => Promise.resolve(new Uint8Array(0));
 
-Deno.test("runLocally function", async (t) => {
+Deno.test("runLocally function sad path", async (t) => {
   await t.step("should be defined", () => {
     assertExists(runLocally);
   });
@@ -59,6 +57,23 @@ Deno.test("runLocally function", async (t) => {
         Error,
         "No function definition for function callback id",
       );
+    },
+  );
+});
+
+Deno.test("runLocally function happy path", async (t) => {
+  await t.step(
+    "should feed dispatch response as stringified JSON to stdout",
+    async () => {
+      const consoleLogSpy = mock.spy(console, "log");
+      await runLocally(
+        fakeManifest,
+        fakeParse,
+        fakeStdinReader,
+        () => Promise.resolve({ something: true }),
+      );
+      mock.assertSpyCallArg(consoleLogSpy, 0, 0, `{"something":true}`);
+      consoleLogSpy.restore();
     },
   );
 });


### PR DESCRIPTION
# Why?

When running locally, if userland code included invalid import paths (which may legit happen by e.g. mistyping a path), the existing logic would assume exceptions raised by the runtime loader that included the message "Module not found" were related to the old multiple-filepath loading semantics. This would obscure issues with userland code (see [this thread](https://slack-pde.slack.com/archives/C01FA1FMGE9/p1660596809010709) for one such example).

This does not affect remote execution of userland functions as that requires a bundling step (ran during `slack deploy`) which would catch any invalid import path issues.

# Details

This PR builds off of #35 to include a refactored `local-run.ts` such that it uses a dependency injection approach to make it more testable.

If we don't like the dependency injection bits for `local-run.ts`, then no problem! Can close this PR and just go with the changes contained in #35.

This PR also includes:

- Simplifying some of the function loading to not try to load multiple files. Instead, LoadFunctionModule always tries to load a single file.
- Removed checking for falsy userland function modules. The type system should guard against this.
- Made some of the errors being raised up more explicit in certain failure modes.
- Expanded some DispatchPayload tests, removed duplicate or no longer relevant DispatchPayload and LoadFunctionModule tests.

# How To Test

You should be able to override the `start` hook in an app to point to your local deno-slack-runtime repo with this branch checked out. Change your app's `slack.json` to something like this:

```
{
  "hooks": {
    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.3.0/mod.ts",
    "start": "deno run -q --config=deno.jsonc --allow-read --allow-net file:///Users/fmaj/src/deno-slack-runtime/src/local-run.ts"
  }
}
```

Next, try `slack run`ning an app with a function that has an invalid import somewhere - like a wrong path to one of the imports. Previously, things would die silently. Now, they die noisily!