### PR TITLE
HERMES-3576: Expose enterprise ID to userland handlers

### DIFF
--- a/src/run-block-actions.ts
+++ b/src/run-block-actions.ts
@@ -14,6 +14,7 @@ export const RunBlockAction = async (
   const { body, context } = payload;
   const env = context.variables || {};
   const team_id = context.team_id || "";
+  const enterprise_id = body.enterprise?.id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
@@ -32,6 +33,7 @@ export const RunBlockAction = async (
     env,
     token,
     team_id,
+    enterprise_id,
     body,
     action: body.actions[0],
   });

--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -14,6 +14,7 @@ export const RunFunction = async (
   const { body, context } = payload;
   const env = context.variables || {};
   const team_id = context.team_id || "";
+  const enterprise_id = body.enterprise_id || "";
   const token = body.event?.bot_access_token || context.bot_access_token || "";
   const functionExecutionId = body.event?.function_execution_id;
   const inputs = body.event?.inputs || {};
@@ -38,6 +39,7 @@ export const RunFunction = async (
     env,
     token,
     team_id,
+    enterprise_id,
     event: body.event,
   });
 

--- a/src/run-unhandled-event.ts
+++ b/src/run-unhandled-event.ts
@@ -14,6 +14,7 @@ export const RunUnhandledEvent = async (
   const { body, context } = payload;
   const env = context.variables || {};
   const team_id = context.team_id || "";
+  const enterprise_id = body.enterprise?.id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
@@ -31,6 +32,7 @@ export const RunUnhandledEvent = async (
     token,
     body,
     team_id,
+    enterprise_id,
   });
 
   return closedResp || {};

--- a/src/run-view-closed.ts
+++ b/src/run-view-closed.ts
@@ -15,6 +15,7 @@ export const RunViewClosed = async (
   const view = body.view;
   const env = context.variables || {};
   const team_id = context.team_id || "";
+  const enterprise_id = body.enterprise?.id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
@@ -33,6 +34,7 @@ export const RunViewClosed = async (
     env,
     token,
     team_id,
+    enterprise_id,
     body,
     view,
   });

--- a/src/run-view-submission.ts
+++ b/src/run-view-submission.ts
@@ -15,6 +15,7 @@ export const RunViewSubmission = async (
   const view = body.view;
   const env = context.variables || {};
   const team_id = context.team_id || "";
+  const enterprise_id = body.enterprise?.id || "";
   const token = body.bot_access_token || context.bot_access_token || "";
   const inputs = body.function_data?.inputs || {};
 
@@ -35,6 +36,7 @@ export const RunViewSubmission = async (
     team_id,
     body,
     view,
+    enterprise_id,
   });
 
   return submissionResp || {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export type FunctionHandlerArgs = {
   inputs: FunctionInputValues;
   token: string;
   team_id: string;
+  enterprise_id: string;
   event: FunctionInvocationBody["event"];
 };
 
@@ -122,6 +123,7 @@ type UnhandledEventHandlerArgs = {
   body: BaseEventInvocationBody;
   token: string;
   team_id: string;
+  enterprise_id: string;
   inputs: FunctionInputValues;
   env: EnvironmentVariables;
 };
@@ -140,6 +142,7 @@ export type BlockActionsHandlerArgs = {
   body: BlockActionInvocationBody;
   token: string;
   team_id: string;
+  enterprise_id: string;
   inputs: FunctionInputValues;
   env: EnvironmentVariables;
 };
@@ -158,6 +161,7 @@ type ViewClosedHandlerArgs = {
   body: ViewClosedInvocationBody;
   token: string;
   team_id: string;
+  enterprise_id: string;
   inputs: FunctionInputValues;
   env: EnvironmentVariables;
 };
@@ -173,6 +177,7 @@ type ViewSubmissionHandlerArgs = {
   body: ViewSubmissionInvocationBody;
   token: string;
   team_id: string;
+  enterprise_id: string;
   inputs: FunctionInputValues;
   env: EnvironmentVariables;
 };


### PR DESCRIPTION
Tested, works in both enterprise and non-enterprise workspaces. In non-enterprise workspaces, the value for `enterprise_id` will be the empty string.