### PR TITLE
[HERMES-4040] Enforce allow-net in `hermes run`

### DIFF
--- a/src/local-run-function.ts
+++ b/src/local-run-function.ts
@@ -1,0 +1,51 @@
+import { createManifest, readAll } from "./deps.ts";
+import { ParsePayload } from "./parse-payload.ts";
+import { DispatchPayload } from "./dispatch-payload.ts";
+
+/**
+ * @description Runs an application function locally by dispatching a payload to it after loading it.
+ */
+export const runLocally = async function (
+  create: typeof createManifest,
+  parse: typeof ParsePayload,
+  readStdin: typeof readAll,
+  dispatch: typeof DispatchPayload,
+): Promise<void> {
+  const workingDirectory = Deno.cwd();
+  const manifest = await create({
+    manifestOnly: true,
+    log: () => {},
+    workingDirectory,
+  });
+  if (!manifest.functions) {
+    throw new Error(
+      `No function definitions were found in the manifest! manifest.functions: ${manifest.functions}`,
+    );
+  }
+  const payload = await parse(readStdin);
+
+  // Finds the corresponding function in the manifest definition, and then uses
+  // the `source_file` property to determine the function module file location
+  const resp = await dispatch(payload, (functionCallbackId) => {
+    const functionDefn = manifest.functions[functionCallbackId];
+    if (!functionDefn) {
+      throw new Error(
+        `No function definition for function callback id ${functionCallbackId} was found in the manifest! manifest.functions: ${manifest.functions}`,
+      );
+    }
+
+    const functionFile =
+      `file://${workingDirectory}/${functionDefn.source_file}`;
+
+    return functionFile;
+  });
+
+  // The CLI expects a JSON payload to be output to stdout
+  // This is formalized in the `run` hook of the CLI/SDK Tech Spec:
+  // https://corp.quip.com/0gDvAsqoaaYE/Proposal-CLI-SDK-Interface#temp:C:fOC1991c5aec8994d0db01d26260
+  console.log(JSON.stringify(resp || {}));
+};
+
+if (import.meta.main) {
+  await runLocally(createManifest, ParsePayload, readAll, DispatchPayload);
+}

--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -1,51 +1,128 @@
-import { createManifest, readAll } from "./deps.ts";
-import { ParsePayload } from "./parse-payload.ts";
-import { DispatchPayload } from "./dispatch-payload.ts";
+import { createManifest, parse } from "./deps.ts";
+
+const SLACK_DEV_DOMAIN_FLAG = "sdk-slack-dev-domain";
 
 /**
- * @description Runs an application function locally by dispatching a payload to it after loading it.
+ * @param args An array of command line flags
+ * @returns The value of the SLACK_DEV_DOMAIN_FLAG flag, or empty string
  */
-export const runLocally = async function (
+const parseDevDomain = (args: string[]): string => {
+  const flags = parse(args);
+  return flags[SLACK_DEV_DOMAIN_FLAG] ?? "";
+};
+
+/**
+ * Returns a module URL string pointing to `file` in the same
+ * directory as `mainModule`.
+ * @param mainModule The currently running Deno module, like from `Deno.mainModule`
+ * @param filename The name of the file to return the URL for
+ * @returns
+ */
+const findRelativeFile = (mainModule: string, filename: string): string => {
+  const moduleUrl = new URL(mainModule);
+  const path = moduleUrl.pathname;
+  const pathComponents = path.split("/");
+  if (pathComponents.length > 0) {
+    pathComponents[pathComponents.length - 1] = filename;
+  } else {
+    pathComponents[0] = filename;
+  }
+  moduleUrl.pathname = pathComponents.join("/");
+  return moduleUrl.href;
+};
+
+/**
+ * Determines the command line for the `deno run` invocation that will actually run the function,
+ * setting the appropriate permissions flags
+ * @param mainModule The URL to the main file being run, from `Deno.mainModule`
+ * @param denoExecutablePath The path to the deno executable
+ * @param manifest The application's manifest
+ * @param devDomain The domain of the slack dev instance being used, or empty string for production
+ * @returns The commandline to run `local-run-function.ts` to actually execute the function
+ */
+export const getCommandline = function (
+  mainModule: string,
+  denoExecutablePath: string,
+  // deno-lint-ignore no-explicit-any
+  manifest: any,
+  devDomain: string,
+): string[] {
+  const command = [
+    denoExecutablePath,
+    "run",
+    "-q",
+    "--config=deno.jsonc",
+    "--allow-read",
+  ];
+
+  const allowedDomains = manifest.outgoing_domains ?? [];
+
+  // If using a dev instance, allow making API calls to that domain
+  // and ignore SSL errors to it
+  if (devDomain !== "") {
+    command.push("--unsafely-ignore-certificate-errors=" + devDomain);
+    allowedDomains.push(devDomain);
+  } else {
+    allowedDomains.push("slack.com");
+  }
+  // Add deno.land to allow uncached remote deps
+  allowedDomains.push("deno.land");
+
+  command.push("--allow-net=" + allowedDomains.join(","));
+  command.push(findRelativeFile(mainModule, "local-run-function.ts"));
+
+  return command;
+};
+
+/**
+ * @description Runs an application locally by calling `deno run` with appropriate flags.
+ */
+export const runWithOutgoingDomains = async function (
   create: typeof createManifest,
-  parse: typeof ParsePayload,
-  readStdin: typeof readAll,
-  dispatch: typeof DispatchPayload,
-): Promise<void> {
+  devDomain: string,
+  // deno-lint-ignore no-explicit-any
+  log: (...any: any) => void,
+): Promise<Deno.ProcessStatus> {
   const workingDirectory = Deno.cwd();
   const manifest = await create({
     manifestOnly: true,
-    log: () => {},
+    log: log,
     workingDirectory,
   });
+
   if (!manifest.functions) {
     throw new Error(
       `No function definitions were found in the manifest! manifest.functions: ${manifest.functions}`,
     );
   }
-  const payload = await parse(readStdin);
 
-  // Finds the corresponding function in the manifest definition, and then uses
-  // the `source_file` property to determine the function module file location
-  const resp = await dispatch(payload, (functionCallbackId) => {
-    const functionDefn = manifest.functions[functionCallbackId];
-    if (!functionDefn) {
-      throw new Error(
-        `No function definition for function callback id ${functionCallbackId} was found in the manifest! manifest.functions: ${manifest.functions}`,
-      );
-    }
+  let denoExecutablePath = "deno";
+  try {
+    denoExecutablePath = Deno.execPath();
+  } catch (e) {
+    log("Error determining deno executable path: ", e);
+  }
 
-    const functionFile =
-      `file://${workingDirectory}/${functionDefn.source_file}`;
+  const command = getCommandline(
+    Deno.mainModule,
+    denoExecutablePath,
+    manifest,
+    devDomain,
+  );
 
-    return functionFile;
+  log("running command: ", ...command);
+
+  const p = Deno.run({
+    cmd: command,
   });
 
-  // The CLI expects a JSON payload to be output to stdout
-  // This is formalized in the `run` hook of the CLI/SDK Tech Spec:
-  // https://corp.quip.com/0gDvAsqoaaYE/Proposal-CLI-SDK-Interface#temp:C:fOC1991c5aec8994d0db01d26260
-  console.log(JSON.stringify(resp || {}));
+  return p.status();
 };
 
 if (import.meta.main) {
-  await runLocally(createManifest, ParsePayload, readAll, DispatchPayload);
+  await runWithOutgoingDomains(
+    createManifest,
+    parseDevDomain(Deno.args),
+    () => {},
+  );
 }

--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -6,7 +6,7 @@ const SLACK_DEV_DOMAIN_FLAG = "sdk-slack-dev-domain";
  * @param args An array of command line flags
  * @returns The value of the SLACK_DEV_DOMAIN_FLAG flag, or empty string
  */
-const parseDevDomain = (args: string[]): string => {
+export const parseDevDomain = (args: string[]): string => {
   const flags = parse(args);
   return flags[SLACK_DEV_DOMAIN_FLAG] ?? "";
 };
@@ -112,9 +112,7 @@ export const runWithOutgoingDomains = async function (
 
   log("running command: ", ...command);
 
-  const p = Deno.run({
-    cmd: command,
-  });
+  const p = Deno.run({ cmd: command });
 
   const status = await p.status();
   if (!status.success) {

--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -82,7 +82,7 @@ export const runWithOutgoingDomains = async function (
   devDomain: string,
   // deno-lint-ignore no-explicit-any
   log: (...any: any) => void,
-): Promise<Deno.ProcessStatus> {
+): Promise<void> {
   const workingDirectory = Deno.cwd();
   const manifest = await create({
     manifestOnly: true,
@@ -116,7 +116,10 @@ export const runWithOutgoingDomains = async function (
     cmd: command,
   });
 
-  return p.status();
+  const status = await p.status();
+  if (!status.success) {
+    Deno.exit(status.code);
+  }
 };
 
 if (import.meta.main) {

--- a/src/tests/local-run-function.test.ts
+++ b/src/tests/local-run-function.test.ts
@@ -1,0 +1,79 @@
+import { assertExists, assertRejects, mock } from "../dev_deps.ts";
+import { runLocally } from "../local-run-function.ts";
+import { BaseEventInvocationBody, InvocationPayload } from "../types.ts";
+
+const ID = "1234";
+// deno-lint-ignore no-explicit-any
+const fakeManifest = async (_: any): Promise<any> => {
+  return await {
+    functions: {
+      [ID]: {
+        source_file: "some/file.ts",
+      },
+    },
+  };
+};
+const noop = () => Promise.resolve(null);
+// deno-lint-ignore no-explicit-any
+const fakeParse = async (_: any): Promise<InvocationPayload<any>> => {
+  return await {} as InvocationPayload<BaseEventInvocationBody>;
+};
+const fakeStdinReader = (
+  // deno-lint-ignore no-explicit-any
+  _: any,
+): Promise<Uint8Array> => Promise.resolve(new Uint8Array(0));
+
+Deno.test("runLocally function sad path", async (t) => {
+  await t.step("should be defined", () => {
+    assertExists(runLocally);
+  });
+  await t.step(
+    "should throw if manifest does not contain a functions field",
+    async () => {
+      await assertRejects(
+        () =>
+          runLocally(
+            (_) => Promise.resolve({ whatever: false }),
+            fakeParse,
+            fakeStdinReader,
+            noop,
+          ),
+        Error,
+        "No function definitions",
+      );
+    },
+  );
+  await t.step(
+    "should throw if manifest does not contain a function definition that matches payload function callback ID",
+    async () => {
+      await assertRejects(
+        () =>
+          runLocally(
+            (_) => (Promise.resolve({ functions: {} })),
+            fakeParse,
+            fakeStdinReader,
+            (_, getFile) => Promise.resolve(getFile(ID)),
+          ),
+        Error,
+        "No function definition for function callback id",
+      );
+    },
+  );
+});
+
+Deno.test("runLocally function happy path", async (t) => {
+  await t.step(
+    "should feed dispatch response as stringified JSON to stdout",
+    async () => {
+      const consoleLogSpy = mock.spy(console, "log");
+      await runLocally(
+        fakeManifest,
+        fakeParse,
+        fakeStdinReader,
+        () => Promise.resolve({ something: true }),
+      );
+      mock.assertSpyCallArg(consoleLogSpy, 0, 0, `{"something":true}`);
+      consoleLogSpy.restore();
+    },
+  );
+});

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -1,79 +1,91 @@
-import { assertExists, assertRejects, mock } from "../dev_deps.ts";
-import { runLocally } from "../local-run.ts";
-import { BaseEventInvocationBody, InvocationPayload } from "../types.ts";
+import { assertEquals } from "../dev_deps.ts";
+import { getCommandline } from "../local-run.ts";
 
-const ID = "1234";
-// deno-lint-ignore no-explicit-any
-const fakeManifest = async (_: any): Promise<any> => {
-  return await {
-    functions: {
-      [ID]: {
-        source_file: "some/file.ts",
-      },
-    },
+const fakeManifest = (...domains: string[]) => {
+  return {
+    functions: ["dummy"],
+    outgoing_domains: domains,
   };
 };
-const noop = () => Promise.resolve(null);
-// deno-lint-ignore no-explicit-any
-const fakeParse = async (_: any): Promise<InvocationPayload<any>> => {
-  return await {} as InvocationPayload<BaseEventInvocationBody>;
-};
-const fakeStdinReader = (
-  // deno-lint-ignore no-explicit-any
-  _: any,
-): Promise<Uint8Array> => Promise.resolve(new Uint8Array(0));
 
-Deno.test("runLocally function sad path", async (t) => {
-  await t.step("should be defined", () => {
-    assertExists(runLocally);
-  });
-  await t.step(
-    "should throw if manifest does not contain a functions field",
-    async () => {
-      await assertRejects(
-        () =>
-          runLocally(
-            (_) => Promise.resolve({ whatever: false }),
-            fakeParse,
-            fakeStdinReader,
-            noop,
-          ),
-        Error,
-        "No function definitions",
-      );
-    },
+const FAKE_DENO_PATH = "/path/to/deno";
+
+const FAKE_DENO_LAND_MODULE =
+  "https://deno.land/x/deno_slack_runtime@0.3.0/local-run.ts";
+const FAKE_DENO_LAND_EXPECTED_MODULE =
+  "https://deno.land/x/deno_slack_runtime@0.3.0/local-run-function.ts";
+const FAKE_FILE_MODULE = "file://tmp/src/local-run.ts";
+const FAKE_FILE_EXPECTED_MODULE = "file://tmp/src/local-run-function.ts";
+
+Deno.test("getCommandline issues right command no dev domain", () => {
+  const command = getCommandline(
+    FAKE_DENO_LAND_MODULE,
+    FAKE_DENO_PATH,
+    fakeManifest("example.com"),
+    "",
   );
-  await t.step(
-    "should throw if manifest does not contain a function definition that matches payload function callback ID",
-    async () => {
-      await assertRejects(
-        () =>
-          runLocally(
-            (_) => (Promise.resolve({ functions: {} })),
-            fakeParse,
-            fakeStdinReader,
-            (_, getFile) => Promise.resolve(getFile(ID)),
-          ),
-        Error,
-        "No function definition for function callback id",
-      );
-    },
-  );
+  assertEquals(command, [
+    FAKE_DENO_PATH,
+    "run",
+    "-q",
+    "--config=deno.jsonc",
+    "--allow-read",
+    "--allow-net=example.com,slack.com,deno.land",
+    FAKE_DENO_LAND_EXPECTED_MODULE,
+  ]);
 });
 
-Deno.test("runLocally function happy path", async (t) => {
-  await t.step(
-    "should feed dispatch response as stringified JSON to stdout",
-    async () => {
-      const consoleLogSpy = mock.spy(console, "log");
-      await runLocally(
-        fakeManifest,
-        fakeParse,
-        fakeStdinReader,
-        () => Promise.resolve({ something: true }),
-      );
-      mock.assertSpyCallArg(consoleLogSpy, 0, 0, `{"something":true}`);
-      consoleLogSpy.restore();
-    },
+Deno.test("getCommandline issues right command with dev domain", () => {
+  const command = getCommandline(
+    FAKE_DENO_LAND_MODULE,
+    FAKE_DENO_PATH,
+    fakeManifest("example.com"),
+    "dev1234.slack.com",
   );
+  assertEquals(command, [
+    FAKE_DENO_PATH,
+    "run",
+    "-q",
+    "--config=deno.jsonc",
+    "--allow-read",
+    "--unsafely-ignore-certificate-errors=dev1234.slack.com",
+    "--allow-net=example.com,dev1234.slack.com,deno.land",
+    FAKE_DENO_LAND_EXPECTED_MODULE,
+  ]);
+});
+
+Deno.test("getCommandline issues right command with no outgoing domains", () => {
+  const command = getCommandline(
+    FAKE_DENO_LAND_MODULE,
+    FAKE_DENO_PATH,
+    fakeManifest(),
+    "",
+  );
+  assertEquals(command, [
+    FAKE_DENO_PATH,
+    "run",
+    "-q",
+    "--config=deno.jsonc",
+    "--allow-read",
+    "--allow-net=slack.com,deno.land",
+    FAKE_DENO_LAND_EXPECTED_MODULE,
+  ]);
+});
+
+Deno.test("getCommandline issues right command with a local file module", () => {
+  const command = getCommandline(
+    FAKE_FILE_MODULE,
+    FAKE_DENO_PATH,
+    fakeManifest(),
+    "",
+  );
+  assertEquals(command, [
+    FAKE_DENO_PATH,
+    "run",
+    "-q",
+    "--config=deno.jsonc",
+    "--allow-read",
+    "--allow-net=slack.com,deno.land",
+    FAKE_FILE_EXPECTED_MODULE,
+  ]);
 });


### PR DESCRIPTION
###  Summary

When you run `hermes run`, it will now enforce the outgoing_domains set in the manifest, using the `--allow-net` parameter to Deno. 

This works by wrapping the existing local-run.ts file executed via the `start` hook (now called local-run-function.ts) with a Deno.run command that sets allow-net. 

As part of this, we need to rework how dev instances work and the --unsafely-ignore-certificate-errors flag is propagated, as it now needs to be passed into the inner Deno.run, but also the dev instances needs to be specified in allow-net so that the functions.completeSuccess callbacks work.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
