### PR TITLE
Add better logging for outgoing domains errors

### DIFF
--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -103,13 +103,26 @@ export const DispatchPayload = async (
       } else {
         console.warn(handlerError.message);
       }
+    } else if (isAllowNetError(handlerError)) {
+      console.warn(
+        "⚠️   deno-slack-runtime: Detected missing network permissions. Add the domain to your manifest's `outgoingDomains` to resolve the `--allow-net` error.",
+      );
+      throw handlerError;
     } else {
+      console.warn(handlerError);
       throw handlerError;
     }
   }
 
   return resp || {};
 };
+
+// deno-lint-ignore no-explicit-any
+function isAllowNetError(e: any): boolean {
+  return e?.name === "PermissionDenied" &&
+    typeof e?.message === "string" &&
+    e?.message.includes("run again with the --allow-net flag");
+}
 
 function getFunctionCallbackID(
   eventType: ValidEventType,

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -120,7 +120,7 @@ export const DispatchPayload = async (
 function isAllowNetError(e: any): boolean {
   return e?.name === "PermissionDenied" &&
     typeof e?.message === "string" &&
-    e?.message.includes("run again with the --allow-net flag");
+    e?.message.includes("--allow-net");
 }
 
 function getFunctionCallbackID(

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -104,9 +104,9 @@ export const DispatchPayload = async (
         console.warn(handlerError.message);
       }
     } else if (isAllowNetError(handlerError)) {
-      console.warn(
-        "⚠️   deno-slack-runtime: Detected missing network permissions. Add the domain to your manifest's `outgoingDomains` to resolve the `--allow-net` error.",
-      );
+      handlerError.message =
+        "Detected missing network permissions; add the domain to your manifest's `outgoingDomains`. Original message: " +
+        handlerError.message;
       throw handlerError;
     } else {
       throw handlerError;

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -109,7 +109,6 @@ export const DispatchPayload = async (
       );
       throw handlerError;
     } else {
-      console.warn(handlerError);
       throw handlerError;
     }
   }

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -462,7 +462,7 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
 
 Deno.test("DispatchPayload custom error handling", async (t) => {
   await t.step(
-    "no call to console.warn() for a generic error",
+    "passes through generic error",
     async () => {
       const payload = generatePayload("test_id");
 
@@ -472,18 +472,16 @@ Deno.test("DispatchPayload custom error handling", async (t) => {
         },
       };
 
-      const consoleWarnSpy = mock.spy(console, "warn");
-
-      await assertRejects(() => DispatchPayload(payload, () => fnModule));
-
-      mock.assertSpyCalls(consoleWarnSpy, 0);
-
-      consoleWarnSpy.restore();
+      await assertRejects(
+        () => DispatchPayload(payload, () => fnModule),
+        Error,
+        "boom",
+      );
     },
   );
 
   await t.step(
-    "console.warn() if an allow-net error is thrown",
+    "customizes error if matches allow net",
     async () => {
       const payload = generatePayload("test_id");
 
@@ -497,13 +495,11 @@ Deno.test("DispatchPayload custom error handling", async (t) => {
         },
       };
 
-      const consoleWarnSpy = mock.spy(console, "warn");
-
-      await assertRejects(() => DispatchPayload(payload, () => fnModule));
-
-      mock.assertSpyCalls(consoleWarnSpy, 1);
-
-      consoleWarnSpy.restore();
+      await assertRejects(
+        () => DispatchPayload(payload, () => fnModule),
+        Error,
+        "add the domain to your manifest's `outgoingDomains`",
+      );
     },
   );
 });

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -462,6 +462,27 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
 
 Deno.test("DispatchPayload custom error handling", async (t) => {
   await t.step(
+    "no call to console.warn() for a generic error",
+    async () => {
+      const payload = generatePayload("test_id");
+
+      const fnModule = {
+        default: () => {
+          throw new Error("boom");
+        },
+      };
+
+      const consoleWarnSpy = mock.spy(console, "warn");
+
+      await assertRejects(() => DispatchPayload(payload, () => fnModule));
+
+      mock.assertSpyCalls(consoleWarnSpy, 0);
+
+      consoleWarnSpy.restore();
+    },
+  );
+
+  await t.step(
     "console.warn() if an allow-net error is thrown",
     async () => {
       const payload = generatePayload("test_id");

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -459,3 +459,30 @@ Deno.test("DispatchPayload with unhandled events", async (t) => {
     },
   );
 });
+
+Deno.test("DispatchPayload custom error handling", async (t) => {
+  await t.step(
+    "console.warn() if an allow-net error is thrown",
+    async () => {
+      const payload = generatePayload("test_id");
+
+      const fnModule = {
+        default: () => {
+          const e = new Error(
+            'Requires net access to "example.com", run again with the --allow-net flag',
+          );
+          e.name = "PermissionDenied";
+          throw e;
+        },
+      };
+
+      const consoleWarnSpy = mock.spy(console, "warn");
+
+      await assertRejects(() => DispatchPayload(payload, () => fnModule));
+
+      mock.assertSpyCalls(consoleWarnSpy, 1);
+
+      consoleWarnSpy.restore();
+    },
+  );
+});


### PR DESCRIPTION
###  Summary

If we catch an exception from user code that indicates they hit an `--allow-net` permissions error, update the message to instruct the user to update outgoingDomains.

Here's what it looks like:

##### hermes run

<img width="978" alt="Screenshot 2023-01-04 at 1 10 32 PM" src="https://user-images.githubusercontent.com/6804/210650579-a7f6e496-2e69-42fe-843c-32adad98823b.png">


#### hermes deploy
<img width="970" alt="Screenshot 2023-01-04 at 1 08 38 PM" src="https://user-images.githubusercontent.com/6804/210650456-38bfa6e0-7ba3-471e-a484-6c92304ec540.png">


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
