### PR TITLE
Log stack traces for caught user errors

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -83,7 +83,10 @@ const startServer = async function (port: number) {
             )
           );
         } catch (e) {
-          console.error(`Unable to run user supplied module caught error ${e}`);
+          const loggable = e.stack ? e.stack : e;
+          console.error(
+            `Caught error from user supplied module: ${loggable}`,
+          );
           await requestEvent.respondWith(
             new Response(`error ${e}`, {
               status: 500,


### PR DESCRIPTION
###  Summary

Exceptions thrown by user code and caught in ROSI's webserver only currently log the error object, which only shows the error message. If `e.stack` is available, we'll now log that instead. This is a non-standard field that works in v8 so that errors can display full stack traces: https://v8.dev/docs/stack-trace-api

Before:
<img width="970" alt="Screenshot 2023-01-04 at 1 08 38 PM" src="https://user-images.githubusercontent.com/6804/210847260-22a2fb2c-9137-47c1-a4ff-684ae86392fe.png">

After:

<img width="1028" alt="Screenshot 2023-01-05 at 9 45 06 AM" src="https://user-images.githubusercontent.com/6804/210847297-162567b7-3a73-48e1-a394-49b2d1e8e27b.png">


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
