### PR TITLE
Improve lint and format guidelines

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -14,11 +14,32 @@ All you need to work on this project is a recent version of [Deno](https://deno.
 
 Test can be run directly with Deno:
 
-    deno task test
+```zsh
+deno task test
+```
 
 You can also run a test coverage report with:
 
-    deno task coverage
+```zsh
+deno task coverage
+```
+
+### Lint and format
+
+The linting and formatting rules are defined in the `deno.jsonc` file, your IDE can be set up to follow these rules:
+
+1. Refer to the [Deno Set Up Your Environment](https://deno.land/manual/getting_started/setup_your_environment) guidelines to set up your IDE with the proper plugin.
+2. Ensure that the `deno.jsonc` file is set as the configuration file for your IDE plugin
+   * If you are using VS code [this](https://deno.land/manual/references/vscode_deno#using-a-configuration-file) is already configured in `.vscode/settings.json`
+
+#### Linting
+
+The list of linting rules can be found in [the linting deno docs](https://lint.deno.land/).
+Currently we apply all recommended rules.
+
+#### Format
+
+The list of format options is defined in the `deno.jsonc` file. They closely resemble the default values.
 
 ### Releasing
 
@@ -28,10 +49,10 @@ To create a new release:
 
 1. Create a new GitHub Release from the [Releases page](https://github.com/slackapi/deno-slack-runtime/releases) by clicking the "Draft a new release" button.
 2. Input a new version manually into the "Choose a tag" input. You can start off by incrementing the version to reflect a patch. (i.e. 1.16.0 -> 1.16.1)
-    - After you input the new version, click the "Create a new tag: x.x.x on publish" button. This won't create your tag immediately.
-    - Auto-generate the release notes by clicking the "Auto-generate release notes" button. This will pull in changes that will be included in your release. 
-    - Flip to the preview mode and review the pull request labels of the changes included in this release (i.e. `semver:minor` `semver:patch`, `semver:major`). Tip: Your release version should be based on the tag of the largest change, so if this release includes a `semver:minor`, the release version in your tag should be upgraded to reflect a minor. 
-    - Ensure that this version adheres to [semantic versioning][semver]. See [Versioning](#versioning) for correct version format. Version tags should match the following pattern: `1.0.1` (no `v` preceding the number).
+    * After you input the new version, click the "Create a new tag: x.x.x on publish" button. This won't create your tag immediately.
+    * Auto-generate the release notes by clicking the "Auto-generate release notes" button. This will pull in changes that will be included in your release.
+    * Flip to the preview mode and review the pull request labels of the changes included in this release (i.e. `semver:minor` `semver:patch`, `semver:major`). Tip: Your release version should be based on the tag of the largest change, so if this release includes a `semver:minor`, the release version in your tag should be upgraded to reflect a minor.
+    * Ensure that this version adheres to [semantic versioning][semver]. See [Versioning](#versioning-and-tags) for correct version format. Version tags should match the following pattern: `1.0.1` (no `v` preceding the number).
 3. Set the "Target" input to the "main" branch.
 4. Name the release title after the version tag.
 5. Make any adjustments to generated release notes to make sure they are accessible and approachable and that an end-user with little context about this project could still understand.
@@ -68,7 +89,6 @@ Labels are used to run issues through an organized workflow. Here are the basic 
 *  `security`: An issue that has special consideration for security reasons.
 *  `good first contribution`: An issue that has a well-defined relatively-small scope, with clear expectations. It helps when the testing approach is also known.
 *  `duplicate`: An issue that is functionally the same as another issue. Apply this only if you've linked the other issue by number.
-
 
 **Triage** is the process of taking new issues that aren't yet "seen" and marking them with a basic
 level of information with labels. An issue should have **one** of the following labels applied:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
   "deno.enable": true,
   "deno.lint": true,
+  "deno.config": "./deno.jsonc",
   "[typescript]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "denoland.vscode-deno"
-  },
-  "editor.tabSize": 2
+  }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,16 @@
 {
+  "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "fmt": {
     "files": {
       "include": ["src"]
+    },
+    "options": {
+      "semiColons": true,
+      "indentWidth": 2,
+      "lineWidth": 80,
+      "proseWrap": "always",
+      "singleQuote": false,
+      "useTabs": false
     }
   },
   "lint": {
@@ -9,10 +18,15 @@
       "include": ["src"]
     }
   },
+  "test": {
+    "files": {
+      "include": ["src"]
+    }
+  },
   "tasks": {
-    "test": "deno fmt --check && deno lint && deno test -A src",
-    "coverage": "deno test -A --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test .coverage",
-    "coverage-lcov": "rm -rf .coverage && deno test -A --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test .coverage --lcov --output=.coverage/lcov.info"
+    "test": "deno fmt --check && deno lint && deno test --allow-read --allow-net",
+    "coverage": "deno test --allow-read --allow-net --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test .coverage",
+    "coverage-lcov": "rm -rf .coverage && deno deno test --allow-read --allow-net --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test .coverage --lcov --output=.coverage/lcov.info"
   },
   "lock": false
 }


### PR DESCRIPTION
###  Summary

This is related to the deno-slack-sdk [local environment changes](https://github.com/slackapi/deno-slack-sdk/pull/141)

This applies the same configurations for linting and formatting as the deno-slack-sdk.

RELEASE NOTE: This PR alone does not require a new release!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
