### PR TITLE
Format docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,46 @@
 # deno-slack-runtime
 
-Helper library for running a Run on Slack Deno function. The goal of this project is to provide modules for:
+Helper library for running a Run on Slack Deno function. The goal of this
+project is to provide modules for:
 
 1. Parsing function execution event payloads into JSON (`src/parse-payload.ts`)
 2. Dynamically loading the target function (`src/load-function-module.ts`)
-3. Marshaling event payloads to individual functions by callback ID and running them (`src/run-function.ts`)
+3. Marshaling event payloads to individual functions by callback ID and running
+   them (`src/run-function.ts`)
 
 This library has two modes of operation:
 
-1. Using `mod.ts` as the entrypoint, a directory containing function code files to be loaded at runtime must be provided as an argument. This directory must contain one source file per function, with each filename matching the function ID, i.e. if a function to be invoked has a `callback_id` of `reverse`, the provided directory argument must contain a `reverse.ts` or a `reverse.js`.
-2. Using `local-run.ts` as the entrypoint, the current working directory must contain a `manifest.json`, `manifest.ts` or `manifest.js` file, which in turn must contain function definitions that include a `source_file` property. This property is used to determine which function to load and run at runtime.
+1. Using `mod.ts` as the entrypoint, a directory containing function code files
+   to be loaded at runtime must be provided as an argument. This directory must
+   contain one source file per function, with each filename matching the
+   function ID, i.e. if a function to be invoked has a `callback_id` of
+   `reverse`, the provided directory argument must contain a `reverse.ts` or a
+   `reverse.js`.
+2. Using `local-run.ts` as the entrypoint, the current working directory must
+   contain a `manifest.json`, `manifest.ts` or `manifest.js` file, which in turn
+   must contain function definitions that include a `source_file` property. This
+   property is used to determine which function to load and run at runtime.
 
-Regardless of which mode of operation used, each runtime definition for a function is specified in it's own file and must be the default export.
+Regardless of which mode of operation used, each runtime definition for a
+function is specified in it's own file and must be the default export.
 
 ## Usage
 
-By default, your Slack app has a `/slack.json` file that defines a `get-hooks` hook. The Slack CLI will automatically use the version of the `deno-slack-runtime` that is specified by the version of the `get-hooks` script that you're using. To use this library via the Slack CLI out of the box, use the `slack run` command in your terminal. This will automatically run the `start` hook and wait for events to parse the payload.
+By default, your Slack app has a `/slack.json` file that defines a `get-hooks`
+hook. The Slack CLI will automatically use the version of the
+`deno-slack-runtime` that is specified by the version of the `get-hooks` script
+that you're using. To use this library via the Slack CLI out of the box, use the
+`slack run` command in your terminal. This will automatically run the `start`
+hook and wait for events to parse the payload.
 
 ### Override
 
-You also have the option to [override this hook](https://github.com/slackapi/deno-slack-hooks#script-overrides)! You can change the script that runs by specifying a new script for the `start` command. For instance, if you wanted to point to your local instance of this repo, you could accomplish that by adding a `start` command to your `/slack.json` file and setting it to the following:
+You also have the option to
+[override this hook](https://github.com/slackapi/deno-slack-hooks#script-overrides)!
+You can change the script that runs by specifying a new script for the `start`
+command. For instance, if you wanted to point to your local instance of this
+repo, you could accomplish that by adding a `start` command to your
+`/slack.json` file and setting it to the following:
 
 ```json
 {
@@ -30,12 +51,18 @@ You also have the option to [override this hook](https://github.com/slackapi/den
 }
 ```
 
-The script may be one of the following, depending on which mode you are operating this library in:
+The script may be one of the following, depending on which mode you are
+operating this library in:
 
-1. Explicit function directory as argument: `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.1.1/mod.ts ./<required-function-directory>`
-2. Local project with a manifest file: `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.1.1/local-run.ts`
+1. Explicit function directory as argument:
+   `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.1.1/mod.ts ./<required-function-directory>`
+2. Local project with a manifest file:
+   `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.1.1/local-run.ts`
 
-⚠️ Don't forget to update the version specifier in the URL inside the above commands to match the version you want to test! You can also drop the `@` and the version specifier to use the latest released version. You can also use the `file:///` protocol to point to a version present on your local filesystem.
+⚠️ Don't forget to update the version specifier in the URL inside the above
+commands to match the version you want to test! You can also drop the `@` and
+the version specifier to use the latest released version. You can also use the
+`file:///` protocol to point to a version present on your local filesystem.
 
 ## CLI
 
@@ -44,17 +71,22 @@ You can also invoke this library directly from the command line:
     deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_runtime@0.1.1/mod.ts [-p <port>]
 
 Which will start an API Server that will exectue user provided code
+
 ### GET /health
 
-Returns `200 OK` when called, the runtime will use this route to ensure the server is ready to handle requests
+Returns `200 OK` when called, the runtime will use this route to ensure the
+server is ready to handle requests
 
 ### POST /functions
 
-Post Body contains the event payload that used to be read via stdout.
-Returns `200 OK` when there are no errors with finding and executing the expected user code. Will return a `500` otherwise.
+Post Body contains the event payload that used to be read via stdout. Returns
+`200 OK` when there are no errors with finding and executing the expected user
+code. Will return a `500` otherwise.
+
 ## Running Tests
 
-If you make changes to this repo, or just want to make sure things are working as desired, you can run:
+If you make changes to this repo, or just want to make sure things are working
+as desired, you can run:
 
     deno task test
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "fmt": {
     "files": {
-      "include": ["src", "docs"]
+      "include": ["src", "docs", "README.md"]
     },
     "options": {
       "semiColons": true,

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "fmt": {
     "files": {
-      "include": ["src"]
+      "include": ["src", "docs"]
     },
     "options": {
       "semiColons": true,


### PR DESCRIPTION
###  Summary

This PR adds `docs` directory and the `README` to the `fmt.files.include` portion of the `deno.jsonc` and runs the formatter.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
