### PR TITLE
Switch from Deno.run to Deno.Command

### DIFF
--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -50,14 +50,12 @@ const findRelativeFile = (
  */
 export const getCommandline = function (
   mainModule: string,
-  denoExecutablePath: string,
   // deno-lint-ignore no-explicit-any
   manifest: any,
   devDomain: string,
   hookCLI: Protocol,
 ): string[] {
   const command = [
-    denoExecutablePath,
     "run",
     "-q",
     "--config=deno.jsonc",
@@ -121,15 +119,18 @@ export const runWithOutgoingDomains = async function (
 
   const command = getCommandline(
     Deno.mainModule,
-    denoExecutablePath,
     manifest,
     devDomain,
     hookCLI,
   );
 
-  const p = Deno.run({ cmd: command });
+  const commander = new Deno.Command(denoExecutablePath, {
+    args: command,
+  });
 
-  const status = await p.status();
+  const subprocess = commander.spawn();
+  const status = await subprocess.status;
+
   if (!status.success) {
     Deno.exit(status.code);
   }


### PR DESCRIPTION
###  Summary

With [1.33](https://github.com/denoland/deno/releases/tag/v1.33.0) came the deprecation of `Deno.run`, so we need to switch to using [`Deno.Command`](https://deno.land/api@v1.33.1?unstable=&s=Deno.Command). This was stabilized as part of the [1.31 release](https://deno.com/blog/v1.31#changes-to-deno-apis), so we might want to wait a bit to allow folks time to upgrade their local version of Deno.

I was only able to get this to work through the `spawn` method to create a child process, I was not able to get `output` or `outputSync` methods to work.

### Testing

Check out this repo and update your `start` hook to point to your local repo. If testing against a dev Slack instance, make sure to add the `sdk-slack-dev-domain` arg at the end
```json
  "start": "deno run --config=deno.jsonc --allow-read --allow-net --allow-run <your-path-here> --protocol=message-boundaries --boundary=jkadfssajdflkjasdfjhdas"
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).