### PR TITLE
Temporarily exclude no-deprecated-deno-api lint rule

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -16,6 +16,10 @@
   "lint": {
     "files": {
       "include": ["src"]
+    },
+    "rules": {
+      // [TODO]: Remove exclusion after we remove Deno.run
+      "exclude": ["no-deprecated-deno-api"]
     }
   },
   "test": {


### PR DESCRIPTION
###  Summary

#51 will move us from `Deno.run` to `Deno.Command` but in the meantime we need to disable this lint rule to prevent our CI/CD checks from failing

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
