### PR TITLE
Payload extraction refactor

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -22,14 +22,14 @@
       "exclude": ["no-deprecated-deno-api"]
     }
   },
-  "test": {
-    "files": {
-      "include": ["src"]
-    }
-  },
+  "lock": false,
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test --allow-read --allow-net",
     "coverage": "deno test --allow-read --allow-net --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test --lcov --output=lcov.info .coverage && deno run --allow-read https://deno.land/x/code_coverage@0.2.0/cli.ts"
   },
-  "lock": false
+  "test": {
+    "files": {
+      "include": ["src"]
+    }
+  }
 }

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -27,6 +27,7 @@ type GetFunctionFileCallback = {
   (functionCallbackId: string): string | FunctionModule;
 };
 
+// A helper structure that maps event names to the functions responsible for invoking userland code with the relevant event's payload
 const EVENT_TO_HANDLER_MAP = {
   [EventTypes.FUNCTION_EXECUTED]: RunFunction,
   [EventTypes.BLOCK_ACTIONS]: RunBlockAction,

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -122,7 +122,7 @@ function getFunctionCallbackID(
   }
 }
 
-function extractBaseHandlerArgsFromPayload(
+export function extractBaseHandlerArgsFromPayload(
   payload: InvocationPayload<ValidInvocationPayloadBody>,
 ): BaseHandlerArgs {
   const { body, context } = payload;

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -74,7 +74,10 @@ export const DispatchPayload = async (
         `Received an unsupported event of type: "${eventType}" for the ${functionCallbackId} function.`,
       );
     } else {
-      resp = EVENT_TO_HANDLER_MAP[eventType](baseHandlerArgs, functionModule);
+      resp = await EVENT_TO_HANDLER_MAP[eventType](
+        baseHandlerArgs,
+        functionModule,
+      );
     }
   } catch (handlerError) {
     if (isUnhandledEventError(handlerError)) {
@@ -128,7 +131,8 @@ export function extractBaseHandlerArgsFromPayload(
   const { body, context } = payload;
   const env = context.variables || {};
   const team_id = context.team_id || "";
-  const enterprise_id = body.enterprise_id || "";
+  const enterprise_id = body.enterprise_id ||
+    (body as BaseEventInvocationBody).enterprise?.id || "";
   const token = body.event?.bot_access_token || context.bot_access_token || "";
   const inputs = body.event?.inputs || {};
   return {

--- a/src/run-block-actions.ts
+++ b/src/run-block-actions.ts
@@ -1,23 +1,16 @@
 import {
+  BaseHandlerArgs,
   BlockActionInvocationBody,
   EventTypes,
   FunctionModule,
-  InvocationPayload,
 } from "./types.ts";
 import { UnhandledEventError } from "./run-unhandled-event.ts";
 
 export const RunBlockAction = async (
-  payload: InvocationPayload<BlockActionInvocationBody>,
+  baseHandlerArgs: BaseHandlerArgs,
   functionModule: FunctionModule,
   // deno-lint-ignore no-explicit-any
 ): Promise<any> => {
-  const { body, context } = payload;
-  const env = context.variables || {};
-  const team_id = context.team_id || "";
-  const enterprise_id = body.enterprise?.id || "";
-  const token = body.bot_access_token || context.bot_access_token || "";
-  const inputs = body.function_data?.inputs || {};
-
   const handler = functionModule.blockActions ||
     functionModule.default?.blockActions;
   if (!handler) {
@@ -26,16 +19,13 @@ export const RunBlockAction = async (
     );
   }
 
+  const blockActionBody = baseHandlerArgs.body as BlockActionInvocationBody;
   // We don't catch any errors the handler may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
   const response: any = await handler({
-    inputs,
-    env,
-    token,
-    team_id,
-    enterprise_id,
-    body,
-    action: body.actions[0],
+    ...baseHandlerArgs,
+    action: blockActionBody.actions[0],
+    body: blockActionBody,
   });
 
   return response || {};

--- a/src/run-block-suggestion.ts
+++ b/src/run-block-suggestion.ts
@@ -1,23 +1,16 @@
 import {
+  BaseHandlerArgs,
   BlockSuggestionInvocationBody,
   EventTypes,
   FunctionModule,
-  InvocationPayload,
 } from "./types.ts";
 import { UnhandledEventError } from "./run-unhandled-event.ts";
 
 export const RunBlockSuggestion = async (
-  payload: InvocationPayload<BlockSuggestionInvocationBody>,
+  baseHandlerArgs: BaseHandlerArgs,
   functionModule: FunctionModule,
   // deno-lint-ignore no-explicit-any
 ): Promise<any> => {
-  const { body, context } = payload;
-  const env = context.variables || {};
-  const team_id = context.team_id || "";
-  const enterprise_id = body.enterprise?.id ?? "";
-  const token = body.bot_access_token || context.bot_access_token || "";
-  const inputs = body.function_data?.inputs || {};
-
   const handler = functionModule.blockSuggestion ||
     functionModule.default?.blockSuggestion;
   if (!handler) {
@@ -26,15 +19,13 @@ export const RunBlockSuggestion = async (
     );
   }
 
+  const blockSuggestionBody = baseHandlerArgs
+    .body as BlockSuggestionInvocationBody;
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
   const response: any = await handler({
-    inputs,
-    env,
-    token,
-    team_id,
-    enterprise_id,
-    body,
+    ...baseHandlerArgs,
+    body: blockSuggestionBody,
   });
 
   return response || {};

--- a/src/run-unhandled-event.ts
+++ b/src/run-unhandled-event.ts
@@ -1,23 +1,12 @@
-import {
-  BaseEventInvocationBody,
-  FunctionModule,
-  InvocationPayload,
-} from "./types.ts";
+import { BaseHandlerArgs, FunctionModule } from "./types.ts";
 
 export const UNHANDLED_EVENT_ERROR = "UnhandledEventError";
 
 export const RunUnhandledEvent = async (
-  payload: InvocationPayload<BaseEventInvocationBody>,
+  baseHandlerArgs: BaseHandlerArgs,
   functionModule: FunctionModule,
   // deno-lint-ignore no-explicit-any
 ): Promise<any> => {
-  const { body, context } = payload;
-  const env = context.variables || {};
-  const team_id = context.team_id || "";
-  const enterprise_id = body.enterprise?.id || "";
-  const token = body.bot_access_token || context.bot_access_token || "";
-  const inputs = body.function_data?.inputs || {};
-
   const handler = functionModule.unhandledEvent ||
     functionModule.default?.unhandledEvent;
   if (!handler) {
@@ -25,14 +14,7 @@ export const RunUnhandledEvent = async (
   }
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
-  const response: any = await handler({
-    inputs,
-    env,
-    token,
-    body,
-    team_id,
-    enterprise_id,
-  });
+  const response: any = await handler(baseHandlerArgs);
 
   return response || {};
 };

--- a/src/run-view-closed.ts
+++ b/src/run-view-closed.ts
@@ -1,24 +1,16 @@
 import {
+  BaseHandlerArgs,
   EventTypes,
   FunctionModule,
-  InvocationPayload,
   ViewClosedInvocationBody,
 } from "./types.ts";
 import { UnhandledEventError } from "./run-unhandled-event.ts";
 
 export const RunViewClosed = async (
-  payload: InvocationPayload<ViewClosedInvocationBody>,
+  baseHandlerArgs: BaseHandlerArgs,
   functionModule: FunctionModule,
   // deno-lint-ignore no-explicit-any
 ): Promise<any> => {
-  const { body, context } = payload;
-  const view = body.view;
-  const env = context.variables || {};
-  const team_id = context.team_id || "";
-  const enterprise_id = body.enterprise?.id || "";
-  const token = body.bot_access_token || context.bot_access_token || "";
-  const inputs = body.function_data?.inputs || {};
-
   const handler = functionModule.viewClosed ||
     functionModule.default?.viewClosed;
   if (!handler) {
@@ -27,16 +19,13 @@ export const RunViewClosed = async (
     );
   }
 
+  const viewClosedBody = baseHandlerArgs.body as ViewClosedInvocationBody;
   // We don't catch any errors the handlers may throw, we let them throw, and stop the process
   // deno-lint-ignore no-explicit-any
   const response: any = await handler({
-    inputs,
-    env,
-    token,
-    team_id,
-    enterprise_id,
-    body,
-    view,
+    ...baseHandlerArgs,
+    body: viewClosedBody,
+    view: viewClosedBody.view,
   });
 
   return response || {};

--- a/src/tests/dispatch-payload.test.ts
+++ b/src/tests/dispatch-payload.test.ts
@@ -4,6 +4,7 @@ import {
   assertMatch,
   assertRejects,
   mock,
+  mockFetch,
   MockProtocol,
   Spy,
 } from "../dev_deps.ts";
@@ -88,7 +89,7 @@ Deno.test("DispatchPayload function", async (t) => {
     },
   );
   await t.step(
-    "should warn if no function callback_id present in payload and no type present",
+    "should warn if no function callback_id present in payload and no type present and return an empty response to ack the event",
     async () => {
       const protocol = MockProtocol();
 

--- a/src/tests/run-block-actions.test.ts
+++ b/src/tests/run-block-actions.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunBlockAction } from "../run-block-actions.ts";
+import { extractBaseHandlerArgsFromPayload } from "../dispatch-payload.ts";
 import { generateBlockActionsPayload } from "./test_utils.ts";
 import { UnhandledEventError } from "../run-unhandled-event.ts";
 import { FunctionModule } from "../types.ts";
@@ -10,7 +11,9 @@ Deno.test("RunBlockAction function", async (t) => {
   });
 
   await t.step("should run handler", async () => {
-    const payload = generateBlockActionsPayload();
+    const args = extractBaseHandlerArgsFromPayload(
+      generateBlockActionsPayload(),
+    );
 
     const blockActionsResp = {
       burp: "adurp",
@@ -22,13 +25,15 @@ Deno.test("RunBlockAction function", async (t) => {
         return blockActionsResp;
       },
     };
-    const resp = await RunBlockAction(payload, fnModule);
+    const resp = await RunBlockAction(args, fnModule);
 
     assertEquals(resp, blockActionsResp);
   });
 
   await t.step("should run nested handler", async () => {
-    const payload = generateBlockActionsPayload();
+    const args = extractBaseHandlerArgsFromPayload(
+      generateBlockActionsPayload(),
+    );
 
     const blockActionsResp = {
       burp: "adurp",
@@ -40,13 +45,15 @@ Deno.test("RunBlockAction function", async (t) => {
     fnModule.default.blockActions = () => {
       return blockActionsResp;
     };
-    const resp = await RunBlockAction(payload, fnModule);
+    const resp = await RunBlockAction(args, fnModule);
 
     assertEquals(resp, blockActionsResp);
   });
 
   await t.step("should run top level handler over nested handler", async () => {
-    const payload = generateBlockActionsPayload();
+    const args = extractBaseHandlerArgsFromPayload(
+      generateBlockActionsPayload(),
+    );
 
     const blockActionsResp = {
       burp: "adurp",
@@ -59,7 +66,7 @@ Deno.test("RunBlockAction function", async (t) => {
       no: "way",
     });
 
-    const resp = await RunBlockAction(payload, fnModule);
+    const resp = await RunBlockAction(args, fnModule);
 
     assertEquals(resp, blockActionsResp);
   });
@@ -67,14 +74,16 @@ Deno.test("RunBlockAction function", async (t) => {
   await t.step(
     "should throw an error if no handler defined",
     async () => {
-      const payload = generateBlockActionsPayload();
+      const args = extractBaseHandlerArgsFromPayload(
+        generateBlockActionsPayload(),
+      );
 
       const fnModule = {
         default: () => ({}),
       };
 
       await assertRejects(
-        () => RunBlockAction(payload, fnModule),
+        () => RunBlockAction(args, fnModule),
         UnhandledEventError,
         "block_actions",
       );

--- a/src/tests/run-block-suggestion.test.ts
+++ b/src/tests/run-block-suggestion.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunBlockSuggestion } from "../run-block-suggestion.ts";
 import { generateBlockSuggestionPayload } from "./test_utils.ts";
+import { extractBaseHandlerArgsFromPayload } from "../dispatch-payload.ts";
 import { UnhandledEventError } from "../run-unhandled-event.ts";
 import { FunctionModule } from "../types.ts";
 
@@ -29,7 +30,9 @@ Deno.test("RunBlockSuggestion function", async (t) => {
   });
 
   await t.step("should run handler", async () => {
-    const payload = generateBlockSuggestionPayload();
+    const args = extractBaseHandlerArgsFromPayload(
+      generateBlockSuggestionPayload(),
+    );
 
     const fnModule = {
       default: () => ({}),
@@ -37,13 +40,15 @@ Deno.test("RunBlockSuggestion function", async (t) => {
         return sampleOptionsResponse;
       },
     };
-    const resp = await RunBlockSuggestion(payload, fnModule);
+    const resp = await RunBlockSuggestion(args, fnModule);
 
     assertEquals(resp, sampleOptionsResponse);
   });
 
   await t.step("should run nested handler", async () => {
-    const payload = generateBlockSuggestionPayload();
+    const args = extractBaseHandlerArgsFromPayload(
+      generateBlockSuggestionPayload(),
+    );
 
     const fnModule: FunctionModule = {
       default: () => ({}),
@@ -51,13 +56,15 @@ Deno.test("RunBlockSuggestion function", async (t) => {
     fnModule.default.blockSuggestion = () => {
       return sampleOptionsResponse;
     };
-    const resp = await RunBlockSuggestion(payload, fnModule);
+    const resp = await RunBlockSuggestion(args, fnModule);
 
     assertEquals(resp, sampleOptionsResponse);
   });
 
   await t.step("should run top level handler over nested handler", async () => {
-    const payload = generateBlockSuggestionPayload();
+    const args = extractBaseHandlerArgsFromPayload(
+      generateBlockSuggestionPayload(),
+    );
 
     const fnModule: FunctionModule = {
       default: () => ({}),
@@ -67,7 +74,7 @@ Deno.test("RunBlockSuggestion function", async (t) => {
       no: "way",
     });
 
-    const resp = await RunBlockSuggestion(payload, fnModule);
+    const resp = await RunBlockSuggestion(args, fnModule);
 
     assertEquals(resp, sampleOptionsResponse);
   });
@@ -75,14 +82,16 @@ Deno.test("RunBlockSuggestion function", async (t) => {
   await t.step(
     "should throw an error if no handler defined",
     async () => {
-      const payload = generateBlockSuggestionPayload();
+      const args = extractBaseHandlerArgsFromPayload(
+        generateBlockSuggestionPayload(),
+      );
 
       const fnModule = {
         default: () => ({}),
       };
 
       await assertRejects(
-        () => RunBlockSuggestion(payload, fnModule),
+        () => RunBlockSuggestion(args, fnModule),
         UnhandledEventError,
         "block_suggestion",
       );

--- a/src/tests/run-function.test.ts
+++ b/src/tests/run-function.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertStringIncludes } from "../dev_deps.ts";
 import { mockFetch } from "../dev_deps.ts";
 import { RunFunction } from "../run-function.ts";
+import { extractBaseHandlerArgsFromPayload } from "../dispatch-payload.ts";
 import { FAKE_ID, generatePayload } from "./test_utils.ts";
 
 Deno.test("RunFunction function", async (t) => {
@@ -28,8 +29,8 @@ Deno.test("RunFunction function", async (t) => {
         },
       );
 
-      const payload = generatePayload("someid");
-      await RunFunction(payload, {
+      const args = extractBaseHandlerArgsFromPayload(generatePayload("someid"));
+      await RunFunction(args, {
         default: async () => {
           return await { error: "zomg!" };
         },
@@ -40,7 +41,7 @@ Deno.test("RunFunction function", async (t) => {
   await t.step(
     "should call completeSuccess API if function successfully completes",
     async () => {
-      const payload = generatePayload("someid");
+      const args = extractBaseHandlerArgsFromPayload(generatePayload("someid"));
       const outputs = { super: "dope" };
 
       mockFetch.mock(
@@ -63,7 +64,7 @@ Deno.test("RunFunction function", async (t) => {
         },
       );
 
-      await RunFunction(payload, {
+      await RunFunction(args, {
         default: async () => {
           return await { outputs };
         },

--- a/src/tests/run-view-closed.test.ts
+++ b/src/tests/run-view-closed.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunViewClosed } from "../run-view-closed.ts";
+import { extractBaseHandlerArgsFromPayload } from "../dispatch-payload.ts";
 import { generateViewClosedPayload } from "./test_utils.ts";
 import { UnhandledEventError } from "../run-unhandled-event.ts";
 import { FunctionModule } from "../types.ts";
@@ -10,7 +11,7 @@ Deno.test("RunViewClosed function", async (t) => {
   });
 
   await t.step("should run handler", async () => {
-    const payload = generateViewClosedPayload();
+    const args = extractBaseHandlerArgsFromPayload(generateViewClosedPayload());
 
     const viewClosedResp = {
       burp: "adurp",
@@ -22,13 +23,13 @@ Deno.test("RunViewClosed function", async (t) => {
         return viewClosedResp;
       },
     };
-    const resp = await RunViewClosed(payload, fnModule);
+    const resp = await RunViewClosed(args, fnModule);
 
     assertEquals(resp, viewClosedResp);
   });
 
   await t.step("should run nested handler", async () => {
-    const payload = generateViewClosedPayload();
+    const args = extractBaseHandlerArgsFromPayload(generateViewClosedPayload());
 
     const viewClosedResp = {
       burp: "adurp",
@@ -40,13 +41,13 @@ Deno.test("RunViewClosed function", async (t) => {
     fnModule.viewClosed = () => {
       return viewClosedResp;
     };
-    const resp = await RunViewClosed(payload, fnModule);
+    const resp = await RunViewClosed(args, fnModule);
 
     assertEquals(resp, viewClosedResp);
   });
 
   await t.step("should run top level handler over nested handler", async () => {
-    const payload = generateViewClosedPayload();
+    const args = extractBaseHandlerArgsFromPayload(generateViewClosedPayload());
 
     const viewClosedResp = {
       burp: "adurp",
@@ -58,7 +59,7 @@ Deno.test("RunViewClosed function", async (t) => {
     };
     fnModule.default.viewClosed = () => ({ no: "way" });
 
-    const resp = await RunViewClosed(payload, fnModule);
+    const resp = await RunViewClosed(args, fnModule);
 
     assertEquals(resp, viewClosedResp);
   });
@@ -66,14 +67,16 @@ Deno.test("RunViewClosed function", async (t) => {
   await t.step(
     "should return an empty resp if no handler defined",
     async () => {
-      const payload = generateViewClosedPayload();
+      const args = extractBaseHandlerArgsFromPayload(
+        generateViewClosedPayload(),
+      );
 
       const fnModule = {
         default: () => ({}),
       };
 
       await assertRejects(
-        () => RunViewClosed(payload, fnModule),
+        () => RunViewClosed(args, fnModule),
         UnhandledEventError,
         "view_closed",
       );

--- a/src/tests/run-view-submission.test.ts
+++ b/src/tests/run-view-submission.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { RunViewSubmission } from "../run-view-submission.ts";
+import { extractBaseHandlerArgsFromPayload } from "../dispatch-payload.ts";
 import { generateViewSubmissionPayload } from "./test_utils.ts";
 import { UnhandledEventError } from "../run-unhandled-event.ts";
 import { FunctionModule } from "../types.ts";
@@ -10,7 +11,9 @@ Deno.test("RunViewSubmission function", async (t) => {
   });
 
   await t.step("should run handler", async () => {
-    const payload = generateViewSubmissionPayload();
+    const args = extractBaseHandlerArgsFromPayload(
+      generateViewSubmissionPayload(),
+    );
 
     const viewSubmissionResp = {
       burp: "adurp",
@@ -22,13 +25,15 @@ Deno.test("RunViewSubmission function", async (t) => {
         return viewSubmissionResp;
       },
     };
-    const resp = await RunViewSubmission(payload, fnModule);
+    const resp = await RunViewSubmission(args, fnModule);
 
     assertEquals(resp, viewSubmissionResp);
   });
 
   await t.step("should run nested handler", async () => {
-    const payload = generateViewSubmissionPayload();
+    const args = extractBaseHandlerArgsFromPayload(
+      generateViewSubmissionPayload(),
+    );
 
     const viewSubmissionResp = {
       burp: "adurp",
@@ -40,7 +45,7 @@ Deno.test("RunViewSubmission function", async (t) => {
     };
     fnModule.default.viewSubmission = () => ({ no: "way" });
 
-    const resp = await RunViewSubmission(payload, fnModule);
+    const resp = await RunViewSubmission(args, fnModule);
 
     assertEquals(resp, viewSubmissionResp);
   });
@@ -48,14 +53,16 @@ Deno.test("RunViewSubmission function", async (t) => {
   await t.step(
     "should return an empty resp if no handler defined",
     async () => {
-      const payload = generateViewSubmissionPayload();
+      const args = extractBaseHandlerArgsFromPayload(
+        generateViewSubmissionPayload(),
+      );
 
       const fnModule = {
         default: () => ({}),
       };
 
       await assertRejects(
-        () => RunViewSubmission(payload, fnModule),
+        () => RunViewSubmission(args, fnModule),
         UnhandledEventError,
         "view_submission",
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type InvocationPayload<Body extends ValidInvocationPayloadBody> = {
 
 export type ValidInvocationPayloadBody =
   | BlockActionInvocationBody
+  | BlockSuggestionInvocationBody
   | ViewSubmissionInvocationBody
   | ViewClosedInvocationBody
   | FunctionInvocationBody
@@ -26,7 +27,7 @@ export type ValidInvocationPayloadBody =
 // Invocation Bodies
 export type FunctionInvocationBody = {
   event: {
-    type: "function_executed";
+    type: typeof EventTypes.FUNCTION_EXECUTED;
     function: {
       callback_id: string;
     };
@@ -81,12 +82,16 @@ export type FunctionHandlerReturnArgs = {
   error?: string;
 };
 
-export type FunctionHandlerArgs = {
+export type BaseHandlerArgs = {
+  body: ValidInvocationPayloadBody;
   env: EnvironmentVariables;
+  enterprise_id: string;
   inputs: FunctionInputValues;
   token: string;
   team_id: string;
-  enterprise_id: string;
+};
+
+export type FunctionHandlerArgs = BaseHandlerArgs & {
   event: FunctionInvocationBody["event"];
 };
 
@@ -128,13 +133,8 @@ export const EventTypes = {
 export type ValidEventType = typeof EventTypes[keyof typeof EventTypes];
 
 // --- Unhandled Event Types --- //
-type UnhandledEventHandlerArgs = {
+type UnhandledEventHandlerArgs = BaseHandlerArgs & {
   body: BaseEventInvocationBody;
-  token: string;
-  team_id: string;
-  enterprise_id: string;
-  inputs: FunctionInputValues;
-  env: EnvironmentVariables;
 };
 
 type UnhandledEventHandler = {
@@ -146,14 +146,9 @@ type UnhandledEventHandler = {
 // deno-lint-ignore no-explicit-any
 type BlockAction = any;
 
-export type BlockActionsHandlerArgs = {
+export type BlockActionsHandlerArgs = BaseHandlerArgs & {
   action: BlockAction;
   body: BlockActionInvocationBody;
-  token: string;
-  team_id: string;
-  enterprise_id: string;
-  inputs: FunctionInputValues;
-  env: EnvironmentVariables;
 };
 
 export type BlockActionsHandler = {
@@ -162,13 +157,8 @@ export type BlockActionsHandler = {
 };
 
 // --- Block Suggestion Types -- //
-export type BlockSuggestionHandlerArgs = {
+export type BlockSuggestionHandlerArgs = BaseHandlerArgs & {
   body: BlockSuggestionInvocationBody;
-  token: string;
-  team_id: string;
-  enterprise_id: string;
-  inputs: FunctionInputValues;
-  env: EnvironmentVariables;
 };
 
 export type BlockSuggestionHandler = {
@@ -180,14 +170,9 @@ export type BlockSuggestionHandler = {
 // deno-lint-ignore no-explicit-any
 type View = any;
 
-type ViewClosedHandlerArgs = {
-  view: View;
+type ViewClosedHandlerArgs = BaseHandlerArgs & {
   body: ViewClosedInvocationBody;
-  token: string;
-  team_id: string;
-  enterprise_id: string;
-  inputs: FunctionInputValues;
-  env: EnvironmentVariables;
+  view: View;
 };
 
 type ViewClosedHandler = {
@@ -196,14 +181,9 @@ type ViewClosedHandler = {
 };
 
 // --- View Submission Types --- //
-type ViewSubmissionHandlerArgs = {
-  view: View;
+type ViewSubmissionHandlerArgs = BaseHandlerArgs & {
   body: ViewSubmissionInvocationBody;
-  token: string;
-  team_id: string;
-  enterprise_id: string;
-  inputs: FunctionInputValues;
-  env: EnvironmentVariables;
+  view: View;
 };
 
 type ViewSubmissionHandler = {


### PR DESCRIPTION
###  Summary

We have separate modules for running/invoking/executing different kinds of events, e.g. `RunFunction`, `RunBlockActions`, `RunViewSubmission`, etc. Each of these has (mostly) duplicate code in how it processes the event _payload_ received from webapp into _arguments_ passed into userland handlers for these events. This PR aims to DRY up this processing wherever possible. With there being 6 different events and event handlers users can define, this is quite a bit of repetition, and with some changes coming in in how the runtime uses some of the payload values to modify behaviour (in particular: setting a DEBUG env var and logging out request/responses to Slack's `complete*` APIs), I thought now was the time to do this. Plus I had a bunch of free time on a plane ride 😄 

Point form summary of the changes:

- Factored out common userland handler arguments into a new `BaseHandlerArgs` type.
- Extraction of common event payload properties into the above new common userland handle arguments `BaseHandlerArgs` type introduced in `DispatchPayload`.
- Each individual event's `Run*` function now responsible only for augmenting the relevant event-specific payload properties into the userland arguments object it passes into userland handlers.
- Instead of a large `switch` statement to route event payloads to the appropriate `Run*` function handling that event, swapped to using a map structure that maps event type names to the relevant `Run*` function handling that event.
- When running the tests locally on my machine on the plane with no wifi, noticed some tests were actually making network calls to the `complete*` APIs 😓 Updated these tests to not make network calls.

I am setting this PR to a draft for now. I want to deploy it to a dev environment and run extensive tests to make sure there are no issues:

- [ ] Run our platform-devxp e2e tests against an environment with this refactor in place
- [ ] Run manual local-run tests against this environment