### PR TITLE
Enable a simplistic debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ project is to provide modules for:
 
 1. Parsing function execution event payloads into JSON (`src/parse-payload.ts`)
 2. Dynamically loading the target function (`src/load-function-module.ts`)
-3. Marshaling event payloads to individual functions by callback ID and running
-   them (`src/run-function.ts`)
+3. Dispatching event payloads to individual functions by callback ID and running
+   them (`src/dispatch-payload.ts`)
 
 This library has two modes of operation:
 
@@ -22,7 +22,7 @@ This library has two modes of operation:
    property is used to determine which function to load and run at runtime.
 
 Regardless of which mode of operation used, each runtime definition for a
-function is specified in it's own file and must be the default export.
+function is specified in its own file and must be the default export.
 
 ## Usage
 

--- a/src/dispatch-payload.ts
+++ b/src/dispatch-payload.ts
@@ -79,6 +79,7 @@ export const DispatchPayload = async (
     resp = await EVENT_TO_HANDLER_MAP[eventType](
       baseHandlerArgs,
       functionModule,
+      hookCLI,
     );
   } catch (handlerError) {
     if (isUnhandledEventError(handlerError)) {

--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -38,7 +38,10 @@ export const RunFunction = async (
       function_execution_id: functionExecutionId,
     };
     if (debugMode) {
-      hookCLI.log("functions.completeError request payload:", errorPayload);
+      hookCLI.log(
+        "functions.completeError request payload:",
+        JSON.stringify(errorPayload, null, 2),
+      );
     }
     const errorResp = await client.apiCall(
       "functions.completeError",
@@ -57,7 +60,10 @@ export const RunFunction = async (
       function_execution_id: functionExecutionId,
     };
     if (debugMode) {
-      hookCLI.log("functions.completeSuccess request payload:", successPayload);
+      hookCLI.log(
+        "functions.completeSuccess request payload:",
+        JSON.stringify(successPayload, null, 2),
+      );
     }
     const successResp = await client.apiCall(
       "functions.completeSuccess",

--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -12,7 +12,7 @@ export const RunFunction = async (
   // TODO: in the future, if we add more of this kind of logging, then perhaps worth considering moving to a structured logger with different log levels
   // this would reduce the amount of `if (debugMode) log(something)` conditional code
   // e.g. https://deno.land/std@0.151.0/log/README.md
-  const debugMode = baseHandlerArgs.env["DEBUG"] == "true";
+  const debugMode = baseHandlerArgs.env["SLACK_DEBUG"] == "true";
 
   if (!functionModule.default) {
     throw new UnhandledEventError(

--- a/src/run-function.ts
+++ b/src/run-function.ts
@@ -1,13 +1,18 @@
-import { BaseSlackAPIClient } from "./deps.ts";
+import { BaseSlackAPIClient, Protocol } from "./deps.ts";
 import { BaseHandlerArgs, EventTypes, FunctionModule } from "./types.ts";
 import { UnhandledEventError } from "./run-unhandled-event.ts";
 
 export const RunFunction = async (
   baseHandlerArgs: BaseHandlerArgs,
   functionModule: FunctionModule,
+  hookCLI: Protocol,
 ): Promise<void> => {
   // TODO: should we throw if this cannot be found? Alternatively / in addition, if calls below to complete* APIs fail, maybe we should throw then?
   const functionExecutionId = baseHandlerArgs.body.event?.function_execution_id;
+  // TODO: in the future, if we add more of this kind of logging, then perhaps worth considering moving to a structured logger with different log levels
+  // this would reduce the amount of `if (debugMode) log(something)` conditional code
+  // e.g. https://deno.land/std@0.151.0/log/README.md
+  const debugMode = baseHandlerArgs.env["DEBUG"] == "true";
 
   if (!functionModule.default) {
     throw new UnhandledEventError(
@@ -28,19 +33,39 @@ export const RunFunction = async (
 
   // App has indicated there's an unrecoverable error with this function invocation
   if (error) {
-    await client.apiCall("functions.completeError", {
+    const errorPayload = {
       error,
       function_execution_id: functionExecutionId,
-    });
+    };
+    if (debugMode) {
+      hookCLI.log("functions.completeError request payload:", errorPayload);
+    }
+    const errorResp = await client.apiCall(
+      "functions.completeError",
+      errorPayload,
+    );
+    if (debugMode) {
+      hookCLI.log("functions.completeError response payload:", errorResp);
+    }
     return;
   }
 
   // App has indicated its function completed successfully
   if (completed) {
-    await client.apiCall("functions.completeSuccess", {
+    const successPayload = {
       outputs,
       function_execution_id: functionExecutionId,
-    });
+    };
+    if (debugMode) {
+      hookCLI.log("functions.completeSuccess request payload:", successPayload);
+    }
+    const successResp = await client.apiCall(
+      "functions.completeSuccess",
+      successPayload,
+    );
+    if (debugMode) {
+      hookCLI.log("functions.completeSuccess response payload:", successResp);
+    }
     return;
   }
 };

--- a/src/tests/run-function.test.ts
+++ b/src/tests/run-function.test.ts
@@ -110,7 +110,10 @@ Deno.test("RunFunction function", async (t) => {
           0,
           "functions.completeError request payload:",
         );
-        assertEquals(logSpy.calls[0].args[1].error, functionOutput.error);
+        assertStringIncludes(
+          logSpy.calls[0].args[1],
+          `"error": "${functionOutput.error}"`,
+        );
         mock.assertSpyCallArg(
           logSpy,
           1,
@@ -147,7 +150,10 @@ Deno.test("RunFunction function", async (t) => {
           0,
           "functions.completeSuccess request payload:",
         );
-        assertEquals(logSpy.calls[0].args[1].outputs, functionOutput.outputs);
+        assertStringIncludes(
+          logSpy.calls[0].args[1],
+          `"super": "dope"`,
+        );
         mock.assertSpyCallArg(
           logSpy,
           1,

--- a/src/tests/run-function.test.ts
+++ b/src/tests/run-function.test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertStringIncludes } from "../dev_deps.ts";
+import {
+  assertEquals,
+  assertStringIncludes,
+  MockProtocol,
+} from "../dev_deps.ts";
 import { mockFetch } from "../dev_deps.ts";
 import { RunFunction } from "../run-function.ts";
 import { extractBaseHandlerArgsFromPayload } from "../dispatch-payload.ts";
@@ -36,7 +40,7 @@ Deno.test("RunFunction function", async (t) => {
         default: async () => {
           return await { error: "zomg!" };
         },
-      });
+      }, MockProtocol());
     },
   );
 
@@ -72,7 +76,7 @@ Deno.test("RunFunction function", async (t) => {
         default: async () => {
           return await { outputs };
         },
-      });
+      }, MockProtocol());
     },
   );
   mockFetch.uninstall();

--- a/src/tests/run-function.test.ts
+++ b/src/tests/run-function.test.ts
@@ -83,6 +83,9 @@ Deno.test("RunFunction function", async (t) => {
   );
 
   await t.step("debug mode enabled", async (tt) => {
+    const evtPayload = generateFunctionExecutedPayload("someid");
+    evtPayload.context.variables = { SLACK_DEBUG: "true" };
+
     await tt.step(
       "should log both request and response payloads to completeError if function fails to complete",
       async () => {
@@ -92,8 +95,6 @@ Deno.test("RunFunction function", async (t) => {
             return new Response('{"ok":true}');
           },
         );
-        const evtPayload = generateFunctionExecutedPayload("someid");
-        evtPayload.context.variables = { DEBUG: "true" };
 
         const args = extractBaseHandlerArgsFromPayload(evtPayload);
         const mockProtocol = MockProtocol();
@@ -132,8 +133,6 @@ Deno.test("RunFunction function", async (t) => {
             return new Response('{"ok":true}');
           },
         );
-        const evtPayload = generateFunctionExecutedPayload("someid");
-        evtPayload.context.variables = { DEBUG: "true" };
 
         const args = extractBaseHandlerArgsFromPayload(evtPayload);
         const mockProtocol = MockProtocol();


### PR DESCRIPTION
...based on the existence of a `DEBUG` env var set to "true". If debug mode is on, the transparent calls to the `functions.complete*` APIs in runtime when executing the main function handler will log their request and response payloads.

When running locally with a `DEBUG=true` local environment variable set and returning an error from a main function, this will look like this:

```
functions.completeError request payload: { error: "yo bad times", function_execution_id: "Fx0590GKA16U" }
functions.completeError response payload: { ok: true }
```

TODOs:

- [x] Test when running locally
- [x] Deploy runtime layer to a dev env and test on a hosted app
- [x] Add unit tests