### PR TITLE
Pre-approve esm.sh network calls for easy access to transpiled modules during local-run

### DIFF
--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -75,8 +75,9 @@ export const getCommandline = function (
   } else {
     allowedDomains.push("slack.com");
   }
-  // Add deno.land to allow uncached remote deps
+  // Add deno.land and esm.sh to allow uncached remote deps
   allowedDomains.push("deno.land");
+  allowedDomains.push("esm.sh");
 
   command.push("--allow-net=" + allowedDomains.join(","));
   command.push(findRelativeFile(mainModule, "local-run-function.ts"));

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -43,7 +43,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,deno.land",
+      "--allow-net=example.com,slack.com,deno.land,esm.sh",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
   });
@@ -64,7 +64,7 @@ Deno.test("getCommandline function", async (t) => {
       "--allow-read",
       "--allow-env",
       "--unsafely-ignore-certificate-errors=dev1234.slack.com",
-      "--allow-net=example.com,dev1234.slack.com,deno.land",
+      "--allow-net=example.com,dev1234.slack.com,deno.land,esm.sh",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
   });
@@ -84,7 +84,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=slack.com,deno.land",
+      "--allow-net=slack.com,deno.land,esm.sh",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
   });
@@ -104,7 +104,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=slack.com,deno.land",
+      "--allow-net=slack.com,deno.land,esm.sh",
       FAKE_FILE_EXPECTED_MODULE,
     ]);
   });
@@ -124,7 +124,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,deno.land",
+      "--allow-net=example.com,slack.com,deno.land,esm.sh",
       "file:///local-run-function.ts",
     ]);
   });
@@ -146,7 +146,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,deno.land",
+      "--allow-net=example.com,slack.com,deno.land,esm.sh",
       "file:///local-run-function.ts",
       "--mycustomflag",
     ]);


### PR DESCRIPTION
Should help address issues like e.g. https://github.com/slack-samples/deno-triage-rotation/pull/32

Closes #56 

Try it out by adding the following to a sample app's `slack.json`:

```
"start" : "deno run -q --config=deno.jsonc --allow-read --allow-net --allow-run --allow-env /Users/fmaj/src/deno-slack-runtime/src/local-run.ts "
```