### PR TITLE
Allow requests to both slack.com and api.slack.com when running in local mode

### DIFF
--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -74,6 +74,7 @@ export const getCommandline = function (
     allowedDomains.push(devDomain);
   } else {
     allowedDomains.push("slack.com");
+    allowedDomains.push("api.slack.com");
   }
   // Add deno.land to allow uncached remote deps
   allowedDomains.push("deno.land");

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -43,7 +43,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,deno.land",
+      "--allow-net=example.com,slack.com,api.slack.com,deno.land",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
   });
@@ -84,7 +84,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=slack.com,deno.land",
+      "--allow-net=slack.com,api.slack.com,deno.land",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
   });
@@ -104,7 +104,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=slack.com,deno.land",
+      "--allow-net=slack.com,api.slack.com,deno.land",
       FAKE_FILE_EXPECTED_MODULE,
     ]);
   });
@@ -124,7 +124,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,deno.land",
+      "--allow-net=example.com,slack.com,api.slack.com,deno.land",
       "file:///local-run-function.ts",
     ]);
   });
@@ -146,7 +146,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,deno.land",
+      "--allow-net=example.com,slack.com,api.slack.com,deno.land",
       "file:///local-run-function.ts",
       "--mycustomflag",
     ]);


### PR DESCRIPTION
Re: https://github.com/slackapi/deno-slack-sdk/issues/254

For local run mode, we, by default, allow network access to slack.com. However, this does not explicitly allow api.slack.com. Some of our APIs, like the SCIM APIs, are available at api.slack.com/scim. So today, developers can't access these APIs when running in local run mode.

Let's fix that!

I checked with the run-on-slack team, and tested this for deployed apps, and this is already allowed there. So this lines up local-run behaviour with deployed behaviour.