### PR TITLE
fix: allow locally-running functions to access files.slack.com

### DIFF
--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -75,6 +75,7 @@ export const getCommandline = function (
   } else {
     allowedDomains.push("slack.com");
     allowedDomains.push("api.slack.com");
+    allowedDomains.push("files.slack.com");
   }
   // Add deno.land to allow uncached remote deps
   allowedDomains.push("deno.land");

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -43,7 +43,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,api.slack.com,deno.land",
+      "--allow-net=example.com,slack.com,api.slack.com,files.slack.com,deno.land",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
   });
@@ -84,7 +84,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=slack.com,api.slack.com,deno.land",
+      "--allow-net=slack.com,api.slack.com,files.slack.com,deno.land",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
   });
@@ -104,7 +104,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=slack.com,api.slack.com,deno.land",
+      "--allow-net=slack.com,api.slack.com,files.slack.com,deno.land",
       FAKE_FILE_EXPECTED_MODULE,
     ]);
   });
@@ -124,7 +124,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,api.slack.com,deno.land",
+      "--allow-net=example.com,slack.com,api.slack.com,files.slack.com,deno.land",
       "file:///local-run-function.ts",
     ]);
   });
@@ -146,7 +146,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
-      "--allow-net=example.com,slack.com,api.slack.com,deno.land",
+      "--allow-net=example.com,slack.com,api.slack.com,files.slack.com,deno.land",
       "file:///local-run-function.ts",
       "--mycustomflag",
     ]);


### PR DESCRIPTION
This should address https://github.com/slackapi/deno-slack-sdk/issues/347, at least for locally running functions.