### PR TITLE
chore: allow sys on local run

### DIFF
--- a/src/local-run.ts
+++ b/src/local-run.ts
@@ -63,6 +63,7 @@ export const getCommandline = function (
     "--config=deno.jsonc",
     "--allow-read",
     "--allow-env",
+    "--allow-sys=osRelease",
   ];
 
   const allowedDomains = manifest.outgoing_domains ?? [];

--- a/src/tests/local-run.test.ts
+++ b/src/tests/local-run.test.ts
@@ -43,6 +43,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
+      "--allow-sys=osRelease",
       "--allow-net=example.com,slack.com,api.slack.com,files.slack.com,deno.land",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
@@ -63,6 +64,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
+      "--allow-sys=osRelease",
       "--unsafely-ignore-certificate-errors=dev1234.slack.com",
       "--allow-net=example.com,dev1234.slack.com,deno.land",
       FAKE_DENO_LAND_EXPECTED_MODULE,
@@ -84,6 +86,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
+      "--allow-sys=osRelease",
       "--allow-net=slack.com,api.slack.com,files.slack.com,deno.land",
       FAKE_DENO_LAND_EXPECTED_MODULE,
     ]);
@@ -104,6 +107,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
+      "--allow-sys=osRelease",
       "--allow-net=slack.com,api.slack.com,files.slack.com,deno.land",
       FAKE_FILE_EXPECTED_MODULE,
     ]);
@@ -124,6 +128,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
+      "--allow-sys=osRelease",
       "--allow-net=example.com,slack.com,api.slack.com,files.slack.com,deno.land",
       "file:///local-run-function.ts",
     ]);
@@ -146,6 +151,7 @@ Deno.test("getCommandline function", async (t) => {
       "--config=deno.jsonc",
       "--allow-read",
       "--allow-env",
+      "--allow-sys=osRelease",
       "--allow-net=example.com,slack.com,api.slack.com,files.slack.com,deno.land",
       "file:///local-run-function.ts",
       "--mycustomflag",


### PR DESCRIPTION
###  Summary

Following the changes in https://github.com/slackapi/deno-slack-hooks/pull/94

This PR allow locally run application to use the `Deno.osRelease();` utility.

This should allow the use of the `@slack/webapi` library

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
