### PR TITLE
fix: invalid imports must be used in order to trigger dynamic import failures

### DIFF
--- a/src/tests/fixtures/functions/importerror.ts
+++ b/src/tests/fixtures/functions/importerror.ts
@@ -1,5 +1,6 @@
 import * as _poo from "no-one-knows-what-this-is-really/mod.ts";
 
 export default async function thisWillFailAtRuntime() {
+  _poo.default();
   return await { outputs: { explosions: true } };
 }


### PR DESCRIPTION
###  Summary

In the latest version of Deno it seems like invalid imports nested in dynamic imports must be used in order to trigger an `import error`, if they are not used they seem to be ignored.

These changes update one of our unit tests to use an invalid import imported dynamically in order to trigger an `import error`

This should unblock #75 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
